### PR TITLE
Change BBO interface

### DIFF
--- a/src/train.jl
+++ b/src/train.jl
@@ -315,7 +315,7 @@ end
 
 BBO() = BBO(:adaptive_de_rand_1_bin)
 
-function sciml_train(loss, opt::BBO = BBO(), data = DEFAULT_DATA;lower_bounds, upper_bounds,
+function sciml_train(loss, _θ, opt::BBO, lower_bounds, upper_bounds, data = DEFAULT_DATA;
                       maxiters = get_maxiters(data), kwargs...)
   local x, cur, state
   cur,state = iterate(data)


### PR DESCRIPTION
I think the API should be more like this. The standard error will be thrown when users don't supply lower and upper bounds. Additonally, let us take in the parameters and do nothing with them. 