### PR TITLE
add analytical tgrad for mass matrix methods

### DIFF
--- a/src/neural_de.jl
+++ b/src/neural_de.jl
@@ -451,7 +451,7 @@ function (n::NeuralODEMM)(x,p=n.p)
         alg_out = n.constraints_model(u,p,t)
         vcat(nn_out,alg_out)
     end
-    dudt_= ODEFunction{false}(f,mass_matrix=n.mass_matrix)
+    dudt_= ODEFunction{false}(f,mass_matrix=n.mass_matrix,tgrad=basic_tgrad)
     prob = ODEProblem{false}(dudt_,x,n.tspan,p)
 
     sense = InterpolatingAdjoint(autojacvec=ZygoteVJP())
@@ -464,7 +464,7 @@ function (n::NeuralODEMM{M})(x,p=n.p) where {M<:FastChain}
         alg_out = n.constraints_model(u,p,t)
         vcat(nn_out,alg_out)
     end
-    dudt_= ODEFunction{false}(f;mass_matrix=n.mass_matrix)
+    dudt_= ODEFunction{false}(f;mass_matrix=n.mass_matrix,tgrad=basic_tgrad)
     prob = ODEProblem{false}(dudt_,x,n.tspan,p)
 
     sense = InterpolatingAdjoint(autojacvec=ZygoteVJP())


### PR DESCRIPTION
However, has a weird Zygote bug:

```julia
Can't differentiate gc_preserve_end expression
error(::String) at error.jl:33
getindex at essentials.jl:591 [inlined]
(::typeof(∂(getindex)))(::Nothing) at interface2.jl:0
iterate at essentials.jl:603 [inlined]
(::typeof(∂(iterate)))(::Nothing) at interface2.jl:0
_compute_eltype at tuple.jl:117 [inlined]
(::typeof(∂(_compute_eltype)))(::Nothing) at interface2.jl:0
eltype at tuple.jl:110 [inlined]
eltype at namedtuple.jl:145 [inlined]
Pairs at iterators.jl:169 [inlined]
pairs at iterators.jl:226 [inlined]
(::typeof(∂(pairs)))(::Nothing) at interface2.jl:0
Type at diffeqfunction.jl:388 [inlined]
(::typeof(∂(Type##kw)))(::Nothing) at interface2.jl:0
NeuralODEMM at neural_de.jl:305 [inlined]
(::typeof(∂(λ)))(::Array{Float64,2}) at interface2.jl:0
predict_n_dae at neural_ode_mm.jl:26 [inlined]
(::typeof(∂(predict_n_dae)))(::Array{Float64,2}) at interface2.jl:0
loss at neural_ode_mm.jl:29 [inlined]
(::Zygote.var"#174#175"{typeof(∂(loss)),Tuple{Tuple{Nothing},Int64}})(::Tuple{Int64,Nothing}) at lib.jl:182
(::Zygote.var"#347#back#176"{Zygote.var"#174#175"{typeof(∂(loss)),Tuple{Tuple{Nothing},Int64}}})(::Tuple{Int64,Nothing}) at adjoint.jl:49
#34 at train.jl:176 [inlined]
(::typeof(∂(λ)))(::Int64) at interface2.jl:0
#36 at interface.jl:36 [inlined]
(::DiffEqFlux.var"#37#50"{DiffEqFlux.var"#34#47"{typeof(loss)}})(::Array{Float32,1}, ::Array{Float32,1}) at train.jl:199
value_gradient!!(::TwiceDifferentiable{Float32,Array{Float32,1},Array{Float32,2},Array{Float32,1}}, ::Array{Float32,1}) at interface.jl:82
initial_state(::BFGS{LineSearches.InitialStatic{Float64},LineSearches.HagerZhang{Float64,Base.RefValue{Bool}},Nothing,Float64,Flat}, ::Optim.Options{Float64,DiffEqFlux.var"#_cb#46"{var"#11#12",Base.Iterators.Cycle{Tuple{DiffEqFlux.NullData}}}}, ::TwiceDifferentiable{Float32,Array{Float32,1},Array{Float32,2},Array{Float32,1}}, ::Array{Float32,1}) at bfgs.jl:66
optimize(::TwiceDifferentiable{Float32,Array{Float32,1},Array{Float32,2},Array{Float32,1}}, ::Array{Float32,1}, ::BFGS{LineSearches.InitialStatic{Float64},LineSearches.HagerZhang{Float64,Base.RefValue{Bool}},Nothing,Float64,Flat}, ::Optim.Options{Float64,DiffEqFlux.var"#_cb#46"{var"#11#12",Base.Iterators.Cycle{Tuple{DiffEqFlux.NullData}}}}) at optimize.jl:33
sciml_train(::Function, ::Array{Float32,1}, ::BFGS{LineSearches.InitialStatic{Float64},LineSearches.HagerZhang{Float64,Base.RefValue{Bool}},Nothing,Float64,Flat}, ::Base.Iterators.Cycle{Tuple{DiffEqFlux.NullData}}; cb::Function, maxiters::Int64, diffmode::DiffEqFlux.ZygoteDiffMode, kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at train.jl:269
sciml_train at train.jl:163 [inlined]
(::DiffEqFlux.var"#sciml_train##kw")(::NamedTuple{(:cb, :maxiters),Tuple{var"#11#12",Int64}}, ::typeof(DiffEqFlux.sciml_train), ::Function, ::Array{Float32,1}, ::BFGS{LineSearches.InitialStatic{Float64},LineSearches.HagerZhang{Float64,Base.RefValue{Bool}},Nothing,Float64,Flat}) at train.jl:163
top-level scope at neural_ode_mm.jl:40
```

in

```julia
using Flux, DiffEqFlux, OrdinaryDiffEq, Optim, Test
#A desired MWE for now, not a test yet.
function f(du,u,p,t)
    y₁,y₂,y₃ = u
    k₁,k₂,k₃ = p
    du[1] = -k₁*y₁ + k₃*y₂*y₃
    du[2] =  k₁*y₁ - k₃*y₂*y₃ - k₂*y₂^2
    du[3] =  y₁ + y₂ + y₃ - 1
    nothing
end
u₀ = [1.0, 0, 0]
M = [1. 0  0
     0  1. 0
     0  0  0]
tspan = (0.0,1.0)
p = [0.04,3e7,1e4]
func = ODEFunction(f,mass_matrix=M)
prob = ODEProblem(func,u₀,tspan,p)
sol = solve(prob,Rodas5(),saveat=0.1)

dudt2 = FastChain(FastDense(3,64,tanh),FastDense(64,2))
ndae = NeuralODEMM(dudt2, (u,p,t) -> [u[1] + u[2] + u[3] - 1], tspan, M, Rodas5(autodiff=false),saveat=0.1)
ndae(u₀)

function predict_n_dae(p)
    ndae(u₀,p)
end
function loss(p)
    pred = predict_n_dae(p)
    loss = sum(abs2,sol .- pred)
    loss,pred
end

cb = function (p,l,pred) #callback function to observe training
  display(l)
  return false
end

l1 = first(loss(ndae.p))
res = DiffEqFlux.sciml_train(loss, ndae.p, BFGS(initial_stepnorm = 0.001), cb = cb, maxiters = 100)
```