### PR TITLE
Outing of constructors + Docstrings

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,5 @@
-using Documenter, DiffEqFlux
+push!(LOAD_PATH, "../src/")
+using Documenter, DocStringExtensions, DiffEqFlux
 
 makedocs(
     sitename = "DiffEqFlux.jl",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,4 @@
-using Documenter, DocStringExtensions, DiffEqFlux
+using Documenter, DiffEqFlux
 
 makedocs(
     sitename = "DiffEqFlux.jl",

--- a/docs/src/examples/LV-ODE.md
+++ b/docs/src/examples/LV-ODE.md
@@ -132,9 +132,3 @@ remade_solution = solve(remake(prob_ode, p = result_ode.minimizer), Tsit5(),
 ```
 
 ![Final plot](https://user-images.githubusercontent.com/1814174/51399500-1f4dd080-1b14-11e9-8c9d-144f93b6eac2.gif)
-
-This shows the evolution of the solutions:
-
-```@example ode
-animate(list_plots) # hide
-```

--- a/src/fast_layers.jl
+++ b/src/fast_layers.jl
@@ -23,7 +23,7 @@ paramlength(c::FastChain) = sum(paramlength(x) for x in c.layers)
 initial_params(c::FastChain) = vcat(initial_params.(c.layers)...)
 
 """
-FastDense(in,out,activation=identity;
+    FastDense(in,out,activation=identity;
           initW = Flux.glorot_uniform, initb = Flux.zeros)
 
 A Dense layer `activation.(W*x + b)` with input size `in` and output size `out`.
@@ -73,7 +73,7 @@ paramlength(f::FastDense) = f.out*(f.in + 1)
 initial_params(f::FastDense) = f.initial_params()
 
 """
-StaticDense(in,out,activation=identity;
+    StaticDense(in,out,activation=identity;
           initW = Flux.glorot_uniform, initb = Flux.zeros)
 
 A Dense layer `activation.(W*x + b)` with input size `in` and output size `out`.

--- a/src/neural_de.jl
+++ b/src/neural_de.jl
@@ -13,11 +13,11 @@ struct NeuralODE{M,P,RE,T,S,A,K} <: NeuralDELayer
 end
 
 """
-Constructs a continuous-time recurrant neural network, also known as a neural
-ordinary differential equation (neural ODE), with a fast gradient calculation
-via adjoints [1]. At a high level this corresponds to solving the forward
-differential equation, using a second differential equation that propagates the
-derivatives of the loss backwards in time.
+    Constructs a continuous-time recurrant neural network, also known as a neural
+    ordinary differential equation (neural ODE), with a fast gradient calculation
+    via adjoints [1]. At a high level this corresponds to solving the forward
+    differential equation, using a second differential equation that propagates the
+    derivatives of the loss backwards in time.
 
 ```julia
 NeuralODE(model,tspan,alg=nothing,args...;kwargs...)
@@ -89,7 +89,7 @@ struct NeuralDSDE{M,P,RE,M2,RE2,T,S,A,K} <: NeuralDELayer
 end
 
 """
-Constructs a neural stochastic differential equation (neural SDE) with diagonal noise.
+    Constructs a neural stochastic differential equation (neural SDE) with diagonal noise.
 
 ```julia
 NeuralDSDE(model1,model2,tspan,alg=nothing,args...;
@@ -162,7 +162,7 @@ struct NeuralSDE{P,M,RE,M2,RE2,T,S,A,K} <: NeuralDELayer
 end
 
 """
-Constructs a neural stochastic differential equation (neural SDE).
+    Constructs a neural stochastic differential equation (neural SDE).
 
 ```julia
 NeuralSDE(model1,model2,tspan,nbrown,alg=nothing,args...;
@@ -234,8 +234,8 @@ struct NeuralCDDE{P,M,RE,H,L,T,S,A,K} <: NeuralDELayer
 end
 
 """
-Constructs a neural delay differential equation (neural DDE) with constant
-delays.
+    Constructs a neural delay differential equation (neural DDE) with constant
+    delays.
 
 ```julia
 NeuralCDDE(model,tspan,hist,lags,alg=nothing,args...;
@@ -309,7 +309,7 @@ struct NeuralDAE{P,M,M2,D,RE,T,S,DV,A,K} <: NeuralDELayer
 end
 
 """
-Constructs a neural differential-algebraic equation (neural DAE).
+    Constructs a neural differential-algebraic equation (neural DAE).
 
 ```julia
 NeuralDAE(model,constraints_model,tspan,alg=nothing,args...;
@@ -374,10 +374,10 @@ struct NeuralODEMM{M,M2,P,RE,T,S,MM,A,K} <: NeuralDELayer
 end
 
 """
-Constructs a physically-constrained continuous-time recurrant neural network,
-also known as a neural differential-algebraic equation (neural DAE), with a
-mass matrix and a fast gradient calculation via adjoints [1]. The mass matrix
-formulation is:
+    Constructs a physically-constrained continuous-time recurrant neural network,
+    also known as a neural differential-algebraic equation (neural DAE), with a
+    mass matrix and a fast gradient calculation via adjoints [1]. The mass matrix
+    formulation is:
 
 ```math
 Mu' = f(u,p,t)

--- a/src/neural_de.jl
+++ b/src/neural_de.jl
@@ -52,7 +52,7 @@ end
 function NeuralODE(model::FastChain,tspan,solver=nothing,args...;kwargs...)
     p = initial_params(model)
     re = nothing
-    NeuralODE(model,p,re,tspan,solver,args;kwargs)
+    NeuralODE(model,p,re,tspan,solver,args,kwargs)
 end
 
 Flux.@functor NeuralODE
@@ -116,7 +116,7 @@ function NeuralDSDE(model1,model2,tspan,solver=nothing,args...;kwargs...)
     p1,re1 = Flux.destructure(model1)
     p2,re2 = Flux.destructure(model2)
     p = [p1;p2]
-    NeuralDSDE(p,length(p1),model1,re1,model2,re2,tspan,solver,args;kwargs)
+    NeuralDSDE(p,length(p1),model1,re1,model2,re2,tspan,solver,args,kwargs)
 end
 
 function NeuralDSDE(model1::FastChain,model2::FastChain,tspan,solver=nothing,args...;kwargs...)

--- a/src/neural_de.jl
+++ b/src/neural_de.jl
@@ -49,7 +49,6 @@ function NeuralODE(model,tspan,solver=nothing,args...;kwargs...)
     p,re = Flux.destructure(model)
     NeuralODE(model,p,re,tspan,solver,args;kwargs)
 end
-
 function NeuralODE(model::FastChain,tspan,solver=nothing,args...;kwargs...)
     p = initial_params(model)
     re = nothing

--- a/src/neural_de.jl
+++ b/src/neural_de.jl
@@ -43,20 +43,17 @@ struct NeuralODE{M,P,RE,T,S,A,K} <: NeuralDELayer
     args::A
     kwargs::K
 
-    function NeuralODE(model,tspan,solver=nothing,args...;kwargs...)
-        p,re = Flux.destructure(model)
-        new{typeof(model),typeof(p),typeof(re),
-            typeof(tspan),typeof(solver),typeof(args),typeof(kwargs)}(
-            model,p,re,tspan,solver,args,kwargs)
-    end
+end
 
-    function NeuralODE(model::FastChain,tspan,solver=nothing,args...;kwargs...)
-        p = initial_params(model)
-        re = nothing
-        new{typeof(model),typeof(p),typeof(re),
-            typeof(tspan),typeof(solver),typeof(args),typeof(kwargs)}(
-            model,p,re,tspan,solver,args,kwargs)
-    end
+function NeuralODE(model,tspan,solver=nothing,args...;kwargs...)
+    p,re = Flux.destructure(model)
+    NeuralODE(model,p,re,tspan,solver,args;kwargs)
+end
+
+function NeuralODE(model::FastChain,tspan,solver=nothing,args...;kwargs...)
+    p = initial_params(model)
+    re = nothing
+    NeuralODE(model,p,re,tspan,solver,args;kwargs)
 end
 
 Flux.@functor NeuralODE
@@ -114,25 +111,22 @@ struct NeuralDSDE{M,P,RE,M2,RE2,T,S,A,K} <: NeuralDELayer
     solver::S
     args::A
     kwargs::K
-    function NeuralDSDE(model1,model2,tspan,solver=nothing,args...;kwargs...)
-        p1,re1 = Flux.destructure(model1)
-        p2,re2 = Flux.destructure(model2)
-        p = [p1;p2]
-        new{typeof(model1),typeof(p),typeof(re1),typeof(model2),typeof(re2),
-            typeof(tspan),typeof(solver),typeof(args),typeof(kwargs)}(p,
-            length(p1),model1,re1,model2,re2,tspan,solver,args,kwargs)
-    end
+end
 
-    function NeuralDSDE(model1::FastChain,model2::FastChain,tspan,solver=nothing,args...;kwargs...)
-        p1 = initial_params(model1)
-        p2 = initial_params(model2)
-        re1 = nothing
-        re2 = nothing
-        p = [p1;p2]
-        new{typeof(model1),typeof(p),typeof(re1),typeof(model2),typeof(re2),
-            typeof(tspan),typeof(solver),typeof(args),typeof(kwargs)}(p,
-            length(p1),model1,re1,model2,re2,tspan,solver,args,kwargs)
-    end
+function NeuralDSDE(model1,model2,tspan,solver=nothing,args...;kwargs...)
+    p1,re1 = Flux.destructure(model1)
+    p2,re2 = Flux.destructure(model2)
+    p = [p1;p2]
+    NeuralDSDE(p,length(p1),model1,re1,model2,re2,tspan,solver,args;kwargs)
+end
+
+function NeuralDSDE(model1::FastChain,model2::FastChain,tspan,solver=nothing,args...;kwargs...)
+    p1 = initial_params(model1)
+    p2 = initial_params(model2)
+    re1 = nothing
+    re2 = nothing
+    p = [p1;p2]
+    NeuralDSDE(p,length(p1),model1,re1,model2,re2,tspan,solver,args,kwargs)
 end
 
 Flux.@functor NeuralDSDE
@@ -191,27 +185,23 @@ struct NeuralSDE{P,M,RE,M2,RE2,T,S,A,K} <: NeuralDELayer
     solver::S
     args::A
     kwargs::K
-    function NeuralSDE(model1,model2,tspan,nbrown,solver=nothing,args...;kwargs...)
-        p1,re1 = Flux.destructure(model1)
-        p2,re2 = Flux.destructure(model2)
-        p = [p1;p2]
-        new{typeof(p),typeof(model1),typeof(re1),typeof(model2),typeof(re2),
-            typeof(tspan),typeof(solver),typeof(args),typeof(kwargs)}(
-            p,length(p1),model1,re1,model2,re2,tspan,nbrown,solver,args,kwargs)
-    end
-
-    function NeuralSDE(model1::FastChain,model2::FastChain,tspan,nbrown,solver=nothing,args...;kwargs...)
-        p1 = initial_params(model1)
-        p2 = initial_params(model2)
-        re1 = nothing
-        re2 = nothing
-        p = [p1;p2]
-        new{typeof(p),typeof(model1),typeof(re1),typeof(model2),typeof(re2),
-            typeof(tspan),typeof(solver),typeof(args),typeof(kwargs)}(
-            p,length(p1),model1,re1,model2,re2,tspan,nbrown,solver,args,kwargs)
-    end
 end
 
+function NeuralSDE(model1,model2,tspan,nbrown,solver=nothing,args...;kwargs...)
+    p1,re1 = Flux.destructure(model1)
+    p2,re2 = Flux.destructure(model2)
+    p = [p1;p2]
+    NeuralSDE(p,length(p1),model1,re1,model2,re2,tspan,nbrown,solver,args,kwargs)
+end
+
+function NeuralSDE(model1::FastChain,model2::FastChain,tspan,nbrown,solver=nothing,args...;kwargs...)
+    p1 = initial_params(model1)
+    p2 = initial_params(model2)
+    re1 = nothing
+    re2 = nothing
+    p = [p1;p2]
+    NeuralSDE(p,length(p1),model1,re1,model2,re2,tspan,nbrown,solver,args,kwargs)
+end
 
 Flux.@functor NeuralSDE
 
@@ -343,13 +333,11 @@ struct NeuralDAE{P,M,M2,D,RE,T,S,DV,A,K} <: NeuralDELayer
     differential_vars::DV
     args::A
     kwargs::K
+end
 
-    function NeuralDAE(model,constraints_model,tspan,solver=nothing,du0=nothing,args...;differential_vars=nothing,kwargs...)
-        p,re = Flux.destructure(model)
-        new{typeof(p),typeof(model),typeof(constraints_model),typeof(du0),typeof(re),
-            typeof(tspan),typeof(solver),typeof(differential_vars),typeof(args),typeof(kwargs)}(
-            model,constraints_model,p,du0,re,tspan,solver,differential_vars,args,kwargs)
-    end
+function NeuralDAE(model,constraints_model,tspan,solver=nothing,du0=nothing,args...;differential_vars=nothing,kwargs...)
+    p,re = Flux.destructure(model)
+    NeuralDAE(model,constraints_model,p,du0,re,tspan,solver,differential_vars,args,kwargs)
 end
 
 Flux.@functor NeuralDAE
@@ -423,21 +411,17 @@ struct NeuralODEMM{M,M2,P,RE,T,S,MM,A,K} <: NeuralDELayer
     mass_matrix::MM
     args::A
     kwargs::K
+end
 
-    function NeuralODEMM(model,constraints_model,tspan,mass_matrix,solver=nothing,args...;kwargs...)
-        p,re = Flux.destructure(model)
-        new{typeof(model),typeof(constraints_model),typeof(p),typeof(re),
-            typeof(tspan),typeof(solver),typeof(mass_matrix),typeof(args),typeof(kwargs)}(
-            model,constraints_model,p,re,tspan,solver,mass_matrix,args,kwargs)
-    end
+function NeuralODEMM(model,constraints_model,tspan,mass_matrix,solver=nothing,args...;kwargs...)
+    p,re = Flux.destructure(model)
+    NeuralODEMM(model,constraints_model,p,re,tspan,solver,mass_matrix,args,kwargs)
+end
 
-    function NeuralODEMM(model::FastChain,constraints_model,tspan,mass_matrix,solver=nothing,args...;kwargs...)
-        p = initial_params(model)
-        re = nothing
-        new{typeof(model),typeof(constraints_model),typeof(p),typeof(re),
-            typeof(tspan),typeof(solver),typeof(mass_matrix),typeof(args),typeof(kwargs)}(
-            model,constraints_model,p,re,tspan,solver,mass_matrix,args,kwargs)
-    end
+function NeuralODEMM(model::FastChain,constraints_model,tspan,mass_matrix,solver=nothing,args...;kwargs...)
+    p = initial_params(model)
+    re = nothing
+    NeuralODEMM(model,constraints_model,p,re,tspan,solver,mass_matrix,args,kwargs)
 end
 
 Flux.@functor NeuralODEMM

--- a/test/neural_de.jl
+++ b/test/neural_de.jl
@@ -45,7 +45,6 @@ grads = Zygote.gradient(()->sum(node(xs)),Flux.params(xs,node))
 @test ! iszero(grads[xs])
 @test ! iszero(grads[node.p])
 
-## Fast
 
 @info "Test some fast layers"
 


### PR DESCRIPTION
After nuking all my changes because I hate git rebase, here is a commit that "outs" the constructors defined in neural_de.jl. Plus a few minor changes to the docstrings. 

Beware: I cannot make it work the docstring generation on my machine. It seems that Documentor cannot find the source files although the path is pushed onto LOAD_PATH. If it works for any of you, then I'll welcome any piece of advice. Otherwise I'll keep debugging.

