### PR TITLE
Docs fix: remove parameter `p` from call of `predict_rd`

### DIFF
--- a/docs/src/examples/LV-Flux.md
+++ b/docs/src/examples/LV-Flux.md
@@ -20,7 +20,7 @@ prob = ODEProblem(lotka_volterra,u0,(0.0,10.0),p)
 Then we define our loss function with `concrete_solve` for the adjoint method:
 
 ```julia
-function predict_rd()
+function predict_rd(p)
   Array(concrete_solve(prob,Tsit5(),u0,saveat=0.1,reltol=1e-4))
 end
 loss_rd() = sum(abs2,x-1 for x in predict_rd(p))

--- a/docs/src/examples/LV-Flux.md
+++ b/docs/src/examples/LV-Flux.md
@@ -20,11 +20,12 @@ prob = ODEProblem(lotka_volterra,u0,(0.0,10.0),p)
 Then we define our loss function with `concrete_solve` for the adjoint method:
 
 ```julia
-function predict_rd(p)
+function predict_rd()
   Array(concrete_solve(prob,Tsit5(),u0,saveat=0.1,reltol=1e-4))
 end
-loss_rd() = sum(abs2,x-1 for x in predict_rd(p))
+loss_rd() = sum(abs2,x-1 for x in predict_rd())
 ```
+Note that the parameters `p` to be optimized are not passed as arguments to the `loss_rd` or `predict_rd` functions.  This is because `Flux.train!` below uses implicit globals.
 
 Now we setup the optimization. Here we choose the `ADAM` optimizer. To tell
 Flux what our parameters to optimize are, we use `Flux.params(p)`. To make the


### PR DESCRIPTION
I couldn't get this example to run without this change.
What's still not clear to me (maybe the docs could explain this?) is why the  `loss_rd()` function isn't called like `loss_rd(p)`.
Surely `Flux.train` is trying to evaluate the impact of calling the `loss_rd` function at different values of `p`, so why is `p` not an argument to the function?