### PR TITLE
Avoid OpenBLAS with BLAS2?

### DIFF
--- a/src/fast_layers.jl
+++ b/src/fast_layers.jl
@@ -50,14 +50,13 @@ ZygoteRules.@adjoint function (f::FastDense)(x,p)
   @static if VERSION >= v"1.5"
     W = @view p[reshape(1:(f.out*f.in),f.out,f.in)]
   else
-    W = p[reshape(1:(f.out*f.in),f.out,f.in)]
+    W = @view p[reshape(1:(f.out*f.in),f.out,f.in)]
   end
 
-  b = p[(f.out*f.in+1):end]
-  r = W*x .+ b
-  ifgpufree(b)
+  #b = p[(f.out*f.in+1):end]
+  #r = W*x .+ b
+  #ifgpufree(b)
 
-  #=
   if typeof(x) <: AbstractVector
     r = p[(f.out*f.in+1):end]
     mul!(r,W,x,one(eltype(x)),one(eltype(x)))
@@ -66,7 +65,6 @@ ZygoteRules.@adjoint function (f::FastDense)(x,p)
     r = reshape(repeat(b,outer=size(x,2)),length(b),size(x,2))
     mul!(r,W,x,one(eltype(x)),one(eltype(x)))
   end
-  =#
 
   y = f.σ.(r)
 


### PR DESCRIPTION
```julia
using Flux, DiffEqFlux, BenchmarkTools
using LinearAlgebra
BLAS.set_num_threads(4)
using Flux: mse

Flux.@adjoint function Flux._restructure(m, xs)
  Flux._restructure(m, xs), dm -> (nothing,Flux.destructure(dm)[1])
end

fastdense = FastDense(784, 32, tanh);
p = initial_params(fastdense);
dense = Dense(784, 32, tanh);
p,re = Flux.destructure(dense);
x = rand(Float32, 784);
y = rand(Float32, 32);

@btime gradient((x,p) -> mse(fastdense(x, p), y), x, p);
# 67.001 μs (51 allocations: 202.67 KiB)
@btime gradient((x,p) -> mse(re(p)(x), y), x, p);
# 151.599 μs (115 allocations: 303.05 KiB)
```