### PR TITLE
Fix parameters for `NeuralODE{TensorLayer}`

### DIFF
--- a/src/DiffEqFlux.jl
+++ b/src/DiffEqFlux.jl
@@ -75,11 +75,11 @@ ZygoteRules.@adjoint Tridiagonal(dl, d, du) = Tridiagonal(dl, d, du), p̄ -> (di
 include("ffjord.jl")
 include("train.jl")
 include("fast_layers.jl")
+include("tensor_product_basis.jl")
+include("tensor_product_layer.jl")
 include("neural_de.jl")
 include("require.jl")
 include("spline_layer.jl")
-include("tensor_product_basis.jl")
-include("tensor_product_layer.jl")
 include("collocation.jl")
 include("hnn.jl")
 

--- a/src/neural_de.jl
+++ b/src/neural_de.jl
@@ -76,7 +76,7 @@ function (n::NeuralODE)(x,p=n.p)
     solve(prob,n.args...;sense=sense,n.kwargs...)
 end
 
-function (n::NeuralODE{M})(x,p=n.p) where {M<:FastChain}
+function (n::NeuralODE{M})(x,p=n.p) where {M<:Union{FastChain,TensorLayer}}
     dudt_(u,p,t) = n.model(u,p)
     ff = ODEFunction{false}(dudt_,tgrad=basic_tgrad)
     prob = ODEProblem{false}(ff,x,n.tspan,p)

--- a/src/neural_de.jl
+++ b/src/neural_de.jl
@@ -59,6 +59,13 @@ struct NeuralODE{M,P,RE,T,A,K} <: NeuralDELayer
             typeof(tspan),typeof(args),typeof(kwargs)}(
             model,p,re,tspan,args,kwargs)
     end
+
+    function NeuralODE(model::TensorLayer,tspan,args...;p = model.p,kwargs...)
+        re = nothing
+        new{typeof(model),typeof(p),typeof(re),
+            typeof(tspan),typeof(args),typeof(kwargs)}(
+            model,p,re,tspan,args,kwargs)
+    end
 end
 
 function (n::NeuralODE)(x,p=n.p)


### PR DESCRIPTION
I added a new constructor for `NeuralODE(model::TensorLayer, ...)` which required me to `include` the `tensor_product_*.jl` files first.

Now `NeuralODE{TensorLayer).p` has parameters as expected:

```julia
julia> using Test, OrdinaryDiffEq, Flux, DiffEqFlux

julia> NN = TensorLayer([LegendreBasis(4), LegendreBasis(4)], 4)

julia> node = NeuralODE(NN, (0.0, 1.0), ROCK4())

julia> node.p |> length
64

julia> @test all(node.p == NN.p)
Test Passed
```

Resolves #411