### PR TITLE
Batched Implementation for FFJORD

### DIFF
--- a/docs/src/examples/normalizing_flows.md
+++ b/docs/src/examples/normalizing_flows.md
@@ -8,7 +8,7 @@ We can use DiffEqFlux.jl to define, train and output the densities computed by C
 using DiffEqFlux, OrdinaryDiffEq, Flux, Optim, Distributions, Zygote
 
 nn = Chain(Dense(1, 3, tanh), Dense(3, 1, tanh))
-tspan = (0.0,10.0)
+tspan = (0.0f0,10.0f0)
 ffjord_test = FFJORD(nn,tspan, Tsit5())
 ```
 
@@ -19,14 +19,14 @@ where we also pass as an input the desired timespan for which the differential e
 First, let's get an array from a normal distribution as the training data
 
 ```julia
-data_train = [Float32(rand(Normal(6.0,0.7))) for i in 1:100]
+data_train = Float32.(rand(Normal(6.0,0.7), 1, 100))
 ```
 
 Now we define a loss function that we wish to minimize
 
 ```julia
 function loss_adjoint(θ)
-    logpx = [ffjord_test(x,θ) for x in data_train]
+    logpx = ffjord_test(data_train,θ)[1]
     loss = -mean(logpx)
 end
 ```
@@ -40,8 +40,8 @@ Here we showcase starting the optimization with `ADAM` to more quickly find a mi
 ```julia
 # Train using the ADAM optimizer
 res1 = DiffEqFlux.sciml_train(loss_adjoint, ffjord_test.p,
-                                          ADAM(0.1), cb = cb,
-                                          maxiters = 100)
+                              ADAM(0.1), cb = cb,
+                              maxiters = 100)
 
 * Status: failure (reached maximum number of iterations)
 
@@ -72,8 +72,8 @@ We then complete the training using a different optimizer starting from where `A
 ```julia
 # Retrain using the LBFGS optimizer
 res2 = DiffEqFlux.sciml_train(loss_adjoint, res1.minimizer,
-                                        LBFGS(),
-                                        allow_f_increases = false)
+                              LBFGS(),
+                              allow_f_increases = false)
 
 * Status: success
 

--- a/src/ffjord.jl
+++ b/src/ffjord.jl
@@ -166,7 +166,7 @@ function (n::FFJORD)(x,p=n.p,regularize=false,e=randn(eltype(x),size(x)),
     @assert monte_carlo
     pz = n.basedist
     sense = InterpolatingAdjoint()
-    ffjord_ = (u, p, t) -> ffjord(u, p, t, n.re, e, regularize)
+    ffjord_ = (u, p, t) -> ffjord(u, p, t, n.re, e, regularize, monte_carlo)
     if regularize
         _z = Zygote.@ignore similar(x, 3, size(x, 2))
         Zygote.@ignore fill!(_z, 0.0f0)

--- a/src/ffjord.jl
+++ b/src/ffjord.jl
@@ -105,18 +105,24 @@ struct FFJORD{M,P,RE,Distribution,T,A,K} <: CNFLayer
     end
 end
 
-function _norm_batched(x::AbstractMatrix)
-    res = similar(x, 1, size(x, 2))
-    for i in 1:size(x, 2)
-        res[1, i] = norm(@view x[:, i])
-    end
-    return res
-end
+_norm_batched(x::AbstractMatrix) = sqrt.(sum(x .^ 2, dims = 1))
 
 function jacobian_fn(f, x::AbstractVector)
-   y::AbstractVector, back = Zygote.pullback(f, x)
-   ȳ(i) = [i == j for j = 1:length(y)]
-   vcat([transpose(back(ȳ(i))[1]) for i = 1:length(y)]...)
+    y::AbstractVector, back = Zygote.pullback(f, x)
+    ȳ(i) = [i == j for j = 1:length(y)]
+    vcat([transpose(back(ȳ(i))[1]) for i = 1:length(y)]...)
+end
+
+function jacobian_fn(f, x::AbstractMatrix)
+    y, back = Zygote.pullback(f, x)
+    z = Zygote.@ignore similar(y)
+    Zygote.@ignore fill!(z, zero(eltype(x)))
+    vec = Vector(undef, size(y, 1))
+    for i in 1:size(y, 1)
+        Zygote.@ignore z[i, :] .+= one(eltype(x))
+        vec[i] = reshape(back(z)[1], 1, size(x)...)
+    end
+    return vcat(vec...)
  end
 
 function cnf(du,u,p,t,re)
@@ -128,20 +134,33 @@ function cnf(du,u,p,t,re)
     du[end] = -trace_jac
 end
 
+_trace_batched(x::AbstractArray{T, 3}) where T =
+    reshape([tr(x[:, :, i]) for i in 1:size(x, 3)], 1, size(x, 3))
+
 function ffjord(u,p,t,re,e,regularize,monte_carlo)
     m = re(p)
     if regularize
         z = u[1:end - 3, :]
-        mz, back = Zygote.pullback(m, z)
-        eJ = back(e)[1]
-        trace_jac = sum(eJ .* e, dims = 1)
+        if monte_carlo
+            mz, back = Zygote.pullback(m, z)
+            eJ = back(e)[1]
+            trace_jac = sum(eJ .* e, dims = 1)
+        else
+            mz = m(z)
+            trace_jac = _trace_batched(jacobian_fn(m, z))
+        end
         return cat(mz, -trace_jac, sum(abs2, mz, dims=1),
                    _norm_batched(eJ), dims = 1)
     else
         z = u[1:end - 1, :]
-        mz, back = Zygote.pullback(m, z)
-        eJ = back(e)[1]
-        trace_jac = sum(eJ .* e, dims = 1)
+        if monte_carlo
+            mz, back = Zygote.pullback(m, z)
+            eJ = back(e)[1]
+            trace_jac = sum(eJ .* e, dims = 1)
+        else
+            mz = m(z)
+            trace_jac = _trace_batched(jacobian_fn(m, z))
+        end
         return cat(mz, -trace_jac, dims = 1)
     end
 end
@@ -162,8 +181,6 @@ end
 # When running on GPU e needs to be passed separately
 function (n::FFJORD)(x,p=n.p,regularize=false,e=randn(eltype(x),size(x)),
                      monte_carlo=true)
-    # TODO: Extend the code to world for non monte carlo
-    @assert monte_carlo
     pz = n.basedist
     sense = InterpolatingAdjoint()
     ffjord_ = (u, p, t) -> ffjord(u, p, t, n.re, e, regularize, monte_carlo)

--- a/test/cnf_test.jl
+++ b/test/cnf_test.jl
@@ -7,7 +7,10 @@ using Distances
 using Zygote
 using DistributionsAD
 using LinearAlgebra
+using Random
 println("Starting tests")
+
+Random.seed!(1999)
 
 ##callback to be used by all tests
 function cb(p,l)
@@ -117,4 +120,4 @@ data_validate = Float32.(rand(Beta(7,7), 1, 100))
 actual_pdf = [pdf(Beta(7,7),r) for r in data_validate]
 learned_pdf = exp.(ffjord_test(data_validate,θopt;monte_carlo=false)[1])
 
-@test totalvariation(learned_pdf, actual_pdf)/100 < 0.30
+@test totalvariation(learned_pdf, actual_pdf)/100 < 0.40

--- a/test/cnf_test.jl
+++ b/test/cnf_test.jl
@@ -1,6 +1,5 @@
 println("Starting precompilation")
 using OrdinaryDiffEq
-println("Starting tests")
 using Flux, DiffEqFlux
 using Test
 using Distributions
@@ -8,6 +7,7 @@ using Distances
 using Zygote
 using DistributionsAD
 using LinearAlgebra
+println("Starting tests")
 
 ##callback to be used by all tests
 function cb(p,l)
@@ -20,49 +20,49 @@ end
 ###
 
 nn = Chain(Dense(1, 1, tanh))
-data_train = [Float32(rand(Beta(7,7))) for i in 1:100]
-tspan = (0.0,10.0)
-cnf_test = DeterministicCNF(nn,tspan,Tsit5())
+data_train = Float32.(rand(Beta(7,7), 1, 100))
+tspan = (0.0f0,1.0f0)
+cnf_test = FFJORD(nn,tspan,Tsit5())
 
 function loss_adjoint(θ)
-    logpx = [cnf_test(x,θ) for x in data_train]
+    logpx = cnf_test(data_train,θ;monte_carlo=false)[1]
     loss = -mean(logpx)
 end
 
-res = DiffEqFlux.sciml_train(loss_adjoint, 0.01.*cnf_test.p,
-                                        ADAM(0.01), cb=cb,
-                                        maxiters = 100)
+res = DiffEqFlux.sciml_train(loss_adjoint, cnf_test.p,
+                             ADAM(0.1), cb=cb,
+                             maxiters = 100)
 
 θopt = res.minimizer
-data_validate = [Float32(rand(Beta(7,7))) for i in 1:100]
+data_validate = Float32.(rand(Beta(7,7), 1, 100))
 actual_pdf = [pdf(Beta(7,7),r) for r in data_validate]
 #use direct trace calculation for predictions
-learned_pdf = [exp(cnf_test(r,θopt)) for r in data_validate]
+learned_pdf = exp.(cnf_test(data_validate,θopt;monte_carlo=false)[1])
 
-@test totalvariation(learned_pdf, actual_pdf)/100 < 0.25
+@test totalvariation(learned_pdf, actual_pdf)/100 < 0.35
 
 ###
 #test for alternative base distribution and deterministic trace CNF
 ###
 
 nn = Chain(Dense(1, 3, tanh), Dense(3, 1, tanh))
-data_train = [Float32(rand(Normal(6.0,0.7))) for i in 1:100]
-tspan = (0.0,10.0)
-cnf_test = DeterministicCNF(nn,tspan,Tsit5(),basedist=MvNormal([0.0],[2.0]))
+data_train = Float32.(rand(Normal(6.0,0.7), 1, 100))
+tspan = (0.0f0,1.0f0)
+cnf_test = FFJORD(nn,tspan,Tsit5();basedist=MvNormal([0.0f0],[2.0f0]))
 
 function loss_adjoint(θ)
-    logpx = [cnf_test(x,θ) for x in data_train]
+    logpx = cnf_test(data_train,θ;monte_carlo=false)[1]
     loss = -mean(logpx)
 end
 
-res = DiffEqFlux.sciml_train(loss_adjoint, 0.01.*cnf_test.p,
-                                          ADAM(0.01), cb = cb,
-                                          maxiters = 300)
+res = DiffEqFlux.sciml_train(loss_adjoint, 0.01f0 .* cnf_test.p,
+                             ADAM(0.01), cb=cb,
+                             maxiters = 300)
 
 θopt = res.minimizer
-data_validate = [Float32(rand(Normal(6.0,0.7))) for i in 1:100]
+data_validate = Float32.(rand(Normal(6.0,0.7), 1, 100))
 actual_pdf = [pdf(Normal(6.0,0.7),r) for r in data_validate]
-learned_pdf = [exp(cnf_test(r, θopt)) for r in data_validate]
+learned_pdf = exp.(cnf_test(data_validate,θopt;monte_carlo=false)[1])
 
 @test totalvariation(learned_pdf, actual_pdf)/100 < 0.25
 
@@ -74,23 +74,23 @@ nn = Chain(Dense(2, 2, tanh))
 μ = ones(2)
 Σ = 7*I + zeros(2,2)
 mv_normal = MvNormal(μ, Σ)
-data_train = [Float32.(rand(mv_normal)) for i in 1:100]
-tspan = (0.0,10.0)
-cnf_test = DeterministicCNF(nn,tspan,Tsit5())
+data_train = Float32.(rand(mv_normal, 100))
+tspan = (0.0,1.0f0)
+cnf_test = FFJORD(nn,tspan,Tsit5())
 
 function loss_adjoint(θ)
-    logpx = [cnf_test(x,θ) for x in data_train]
+    logpx = cnf_test(data_train,θ;monte_carlo=false)[1]
     loss = -mean(logpx)
 end
 
-res = DiffEqFlux.sciml_train(loss_adjoint, cnf_test.p,
-                                          ADAM(0.1), cb = cb,
-                                          maxiters = 300)
+res = DiffEqFlux.sciml_train(loss_adjoint, 0.01f0 .* cnf_test.p,
+                             ADAM(0.1), cb=cb,
+                             maxiters = 300)
 
 θopt = res.minimizer
-data_validate = [Float32.(rand(mv_normal)) for i in 1:100]
-actual_pdf = [pdf(mv_normal,r) for r in data_validate]
-learned_pdf = [exp(cnf_test(r, θopt)) for r in data_validate]
+data_validate = Float32.(rand(mv_normal, 100))
+actual_pdf = [pdf(mv_normal,data_validate[:, i]) for i in 1:size(data_validate, 2)]
+learned_pdf = exp.(cnf_test(data_validate,θopt;monte_carlo=false)[1])
 
 @test totalvariation(learned_pdf, actual_pdf)/100 < 0.25
 
@@ -100,7 +100,7 @@ learned_pdf = [exp(cnf_test(r, θopt)) for r in data_validate]
 
 nn = Chain(Dense(1, 1, tanh))
 data_train = Float32.(rand(Beta(7,7), 1, 100))
-tspan = (0.0,10.0)
+tspan = (0.0f0,1.0f0)
 ffjord_test = FFJORD(nn,tspan,Tsit5())
 
 function loss_adjoint(θ)
@@ -109,14 +109,12 @@ function loss_adjoint(θ)
 end
 
 res = DiffEqFlux.sciml_train(loss_adjoint, 0.01f0 .* ffjord_test.p,
-                             ADAM(0.01), cb = cb,
+                             ADAM(0.1), cb = cb,
                              maxiters = 100)
-
 
 θopt = res.minimizer
 data_validate = Float32.(rand(Beta(7,7), 1, 100))
 actual_pdf = [pdf(Beta(7,7),r) for r in data_validate]
-#use direct trace calculation for predictions
-learned_pdf = exp.(ffjord_test(data_validate,θopt,false,randn(Float32,size(data_validate)),false)[1])
+learned_pdf = exp.(ffjord_test(data_validate,θopt;monte_carlo=false)[1])
 
-@test totalvariation(learned_pdf, actual_pdf)/100 < 0.25
+@test totalvariation(learned_pdf, actual_pdf)/100 < 0.30


### PR DESCRIPTION
TODOs:
- [x] Test that this works ~(this was part of another codebase and I haven't yet tested if it integrates correctly here)~
- [ ] Type Inference fails
- [x] Batched version for the non-monte carlo solution.

Fixes #413
Fixes #342 

Some runtime stats:
For a Batch size of 100 on CPU, it takes 2.2 mins per iteration of training.
For a Batch size of 1k on GPU, it takes 0.52s per training iteration.

All of these use the model from #413 