### PR TITLE
Another strategy to avoid local minima

### DIFF
--- a/docs/src/examples/local_minima.md
+++ b/docs/src/examples/local_minima.md
@@ -140,4 +140,4 @@ savefig("fullplot.png")
 ![](https://user-images.githubusercontent.com/1814174/81901711-f82ed400-958c-11ea-9ba2-2b1f213b865a.png)
 
 And there we go, a robust strategy for fitting an equation that would otherwise
-get stuck in a local optima.
+get stuck in a local optima..

--- a/docs/src/examples/local_minima.md
+++ b/docs/src/examples/local_minima.md
@@ -7,6 +7,7 @@ there are many strategies to avoid local minima:
 2. Weigh the loss function to allow for fitting earlier portions first
 3. Changing the optimizers to `allow_f_increases`
 4. Iteratively grow the fit
+5. Training the initial conditions and the parmeters to start
 
 ## `allow_f_increases=true`
 
@@ -139,5 +140,114 @@ savefig("fullplot.png")
 
 ![](https://user-images.githubusercontent.com/1814174/81901711-f82ed400-958c-11ea-9ba2-2b1f213b865a.png)
 
-And there we go, a robust strategy for fitting an equation that would otherwise
-get stuck in a local optima..
+## Training both the initial conditions and the parameters to start
+
+In this example we will show how to use strategy (5) in order to accomplish the
+same goal, except rather than growing the trajectory iteratively, we can train on
+the whole trajectory. We do this by allowing the neural ODE to learn both the 
+initial conditions and parameters to start, and then reset the initial conditions
+back and train only the parameters. Note: this strategy is demonstrated for the (0, 5)
+time span and (0, 10), any longer and more iterations will be required. Alternatively,
+one could use a mix of (4) and (5), or breaking up the trajectory into chunks and just (5).
+
+```julia
+
+using DiffEqFlux, OrdinaryDiffEq, Flux, Optim, Plots, DifferentialEquations
+
+
+#Starting example with tspan (0, 5)
+u0 = Float32[2.0; 0.0]
+datasize = 30
+tspan = (0.0f0, 5.0f0)
+tsteps = range(tspan[1], tspan[2], length = datasize)
+
+function trueODEfunc(du, u, p, t)
+    true_A = [-0.1 2.0; -2.0 -0.1]
+    du .= ((u.^3)'true_A)'
+end
+
+prob_trueode = ODEProblem(trueODEfunc, u0, tspan)
+ode_data = Array(solve(prob_trueode, Tsit5(), saveat = tsteps))
+
+#Using flux here to easily demonstrate the idea, but this can be done with sciml_train!
+dudt2 = Chain(Dense(2,16, tanh),
+             Dense(16,2))
+
+
+p,re = Flux.destructure(dudt2) # use this p as the initial condition!
+dudt(u,p,t) = re(p)(u) # need to restrcture for backprop!
+prob = ODEProblem(dudt,u0,tspan)
+
+function predict_n_ode()
+    Array(solve(prob,u0=u0,p=p, saveat=tsteps))
+end
+
+function loss_n_ode()
+      pred = predict_n_ode()
+      sqnorm(x) = sum(abs2, x)
+      loss = sum(abs2,ode_data .- pred)
+      loss
+end
+
+function cb(;doplot=false) #callback function to observe training
+    pred = predict_n_ode()
+    display(sum(abs2,ode_data .- pred))
+    if doplot
+      # plot current prediction against data
+      pl = plot(tsteps,ode_data[1,:],label="data")
+      plot!(pl,tsteps,pred[1,:],label="prediction")
+      display(plot(pl))
+    end
+    return false
+end
+predict_n_ode()
+loss_n_ode()
+cb(;doplot=true)
+
+data = Iterators.repeated((), 1000)
+
+#Specify to flux to include both the initial conditions (IC) and parameters of the NODE to train
+Flux.train!(loss_n_ode, Flux.params(u0, p), data,
+                    Flux.Optimise.ADAM(0.05), cb = cb)
+
+#Here we reset the IC back to the original and train only the NODE parameters
+u0 = Float32[2.0; 0.0]
+Flux.train!(loss_n_ode, Flux.params(p), data,
+            Flux.Optimise.ADAM(0.05), cb = cb)
+
+cb(;doplot=true)
+
+#Now use the same technique for a longer tspan (0, 10)
+datasize = 30
+tspan = (0.0f0, 10.0f0)
+tsteps = range(tspan[1], tspan[2], length = datasize)
+
+prob_trueode = ODEProblem(trueODEfunc, u0, tspan)
+ode_data = Array(solve(prob_trueode, Tsit5(), saveat = tsteps))
+
+dudt2 = Chain(Dense(2,16, tanh),
+             Dense(16,2))
+
+p,re = Flux.destructure(dudt2) # use this p as the initial condition!
+dudt(u,p,t) = re(p)(u) # need to restrcture for backprop!
+prob = ODEProblem(dudt,u0,tspan)
+
+
+
+data = Iterators.repeated((), 1500)
+
+Flux.train!(loss_n_ode, Flux.params(u0, p), data,
+                    Flux.Optimise.ADAM(0.05), cb = cb)
+
+
+
+u0 = Float32[2.0; 0.0]
+Flux.train!(loss_n_ode, Flux.params(p), data,
+            Flux.Optimise.ADAM(0.05), cb = cb)
+
+cb(;doplot=true)
+
+```
+
+And there we go, a set of robust strategies for fitting an equation that would otherwise
+get stuck in a local optima.


### PR DESCRIPTION
I discovered another strategy in order for one to be able to train a neural ODE and avoid local minima. I used flux because I didn't know how to do it with sciml, but it's pretty straightforward. Simply train both the initial conditions and the parameters first, and then reset the IC back to it's original values and train only the parameters. Follow it up with a longer ADAM run or BFGS for fine tuning. Sometimes in the first training round it doesn't fully converge (for the longer timespan like 0,10), but just run both iterations until their end or add more iterations and it always converges. Going to post the code here and then update the PR with the documentation added once the idea is verified.

```julia
using DiffEqFlux, OrdinaryDiffEq, Flux, Optim, Plots, DifferentialEquations


#Starting with an example with tspan (0, 5)
u0 = Float32[2.0; 0.0]
datasize = 30
tspan = (0.0f0, 5.0f0)
tsteps = range(tspan[1], tspan[2], length = datasize)

function trueODEfunc(du, u, p, t)
    true_A = [-0.1 2.0; -2.0 -0.1]
    du .= ((u.^3)'true_A)'
end

prob_trueode = ODEProblem(trueODEfunc, u0, tspan)
ode_data = Array(solve(prob_trueode, Tsit5(), saveat = tsteps))

dudt2 = Chain(Dense(2,16, tanh),
             Dense(16,2))


p,re = Flux.destructure(dudt2) # use this p as the initial condition!
dudt(u,p,t) = re(p)(u) # need to restrcture for backprop!
prob = ODEProblem(dudt,u0,tspan)

function predict_n_ode()
    Array(solve(prob,u0=u0,p=p, saveat=tsteps, maxiters = 1e10))
end

function loss_n_ode()
      pred = predict_n_ode()
      sqnorm(x) = sum(abs2, x)
      loss = sum(abs2,ode_data .- pred)
      loss
end

function cb(;doplot=false) #callback function to observe training
    pred = predict_n_ode()
    display(sum(abs2,ode_data .- pred))
    if doplot
      # plot current prediction against data
      pl = plot(tsteps,ode_data[1,:],label="data")
      plot!(pl,tsteps,pred[1,:],label="prediction")
      display(plot(pl))
    end
    return false
end
predict_n_ode()
loss_n_ode()
cb(;doplot=true)

data = Iterators.repeated((), 1000)

Flux.train!(loss_n_ode, Flux.params(u0, p), data,
                    Flux.Optimise.ADAM(0.05), cb = cb)

u0 = Float32[2.0; 0.0]
Flux.train!(loss_n_ode, Flux.params(p), data,
            Flux.Optimise.ADAM(0.05), cb = cb)

#Now use the same technique for longer tspan (0, 10)
datasize = 30
tspan = (0.0f0, 10.0f0)
tsteps = range(tspan[1], tspan[2], length = datasize)

prob_trueode = ODEProblem(trueODEfunc, u0, tspan)
ode_data = Array(solve(prob_trueode, Tsit5(), saveat = tsteps))

dudt2 = Chain(Dense(2,16, tanh),
             Dense(16,2))


p,re = Flux.destructure(dudt2) # use this p as the initial condition!
dudt(u,p,t) = re(p)(u) # need to restrcture for backprop!
prob = ODEProblem(dudt,u0,tspan)
predict_n_ode()
loss_n_ode()
cb(;doplot=true)

data = Iterators.repeated((), 1500)

Flux.train!(loss_n_ode, Flux.params(u0, p), data,
                    Flux.Optimise.ADAM(0.05), cb = cb)

u0 = Float32[2.0; 0.0]
Flux.train!(loss_n_ode, Flux.params(p), data,
            Flux.Optimise.ADAM(0.05), cb = cb)
```