### PR TITLE
Scimltraindoc

### DIFF
--- a/docs/src/Scimltrain.md
+++ b/docs/src/Scimltrain.md
@@ -61,3 +61,8 @@ loss. This allows for reusing instead of recalculating. The callback function
 must return a boolean where if `true`, then the optimizer will prematurely end
 the optimization. It is called after every successful step, something that is
 defined in an optimizer-dependent manner.
+
+## Solution structure
+
+`sciml_train` returns its solution as a struct of type `Optim.MultivariateOptimizationResults`. Fields of interest include 
+`minimizer` array containing optimized model parameters, the `minimum` loss function value, number of `iterations`, `time_run` in seconds, `stopped_by` criteria as symbols, and `method` describing optimization algorithm parameters. Boolean fields describe whether `iteration_converged`, `x_converged`, and `is_success`.

--- a/src/train.jl
+++ b/src/train.jl
@@ -1,3 +1,23 @@
+"""
+```julia
+solution = sciml_train(loss, θ, opt [, adtype])
+```
+
+Trains a scientific machine learning problem to minimize the specified  `loss` function with 
+parameters θ. The optimization backend is specified by `opt`, and optionallly the type of automatic
+differentiation `adtype`. Available backends include Flux, Optim, and others, e.g. 
+`BFGS()`.
+
+The returned `solution` is an `Optim.MultivariateOptimizationResults` struct, with 
+notable fields `minimum` loss value, number of `iterations`, `time_run` in seconds,
+`stopped_by` criteria as symbols, and optimization algorithm `method` with parameters. 
+Boolean fields describe whether `iteration_converged`, `x_converged`, and `is_success`.
+
+Optional input arguments `args` and keyword arguments `kwargs` are splatted to the
+optimization problem and solve functions. Notable kwarg specifies the `cb = callback`
+function, which is called after each step, with input arguments θ and the `loss` value.
+
+"""
 function sciml_train(loss, θ, opt, adtype::DiffEqBase.AbstractADType = GalacticOptim.AutoZygote(), args...; kwargs...)
   optf = GalacticOptim.OptimizationFunction((x, p) -> loss(x), adtype)
   optfunc = GalacticOptim.instantiate_function(optf, θ, adtype, nothing)


### PR DESCRIPTION
Here's some documentation for `sciml_train`, in the form of a brief docstring and a small update to the markdown documentation. The latter briefly describes the struct that `sciml_train` returns. I realize that everything is transient as `GalacticOptim` is being developed, but I think there are others like me who are puzzling over how to call this function. Perhaps this could serve as a useful placeholder for the eventual form everything will take. Thanks for putting together an extremely impressive ecosystem in DiffEqFlux.