### PR TITLE
Update Flux.md

### DIFF
--- a/docs/src/Flux.md
+++ b/docs/src/Flux.md
@@ -27,7 +27,8 @@ ode_data = Array(solve(prob,Tsit5(),saveat=t))
 dudt2 = Chain(x -> x.^3,
              Dense(2,50,tanh),
              Dense(50,2))
-dudt(u,p,t) = dudt2(u)
+p,re = Flux.destructure(dudt2) # use this p as the initial condition!
+dudt(u,p,t) = re(p)(u) # need to restrcture for backprop!
 prob = ODEProblem(dudt,u0,tspan)
 
 function predict_n_ode()


### PR DESCRIPTION
Minor mistake in the documentation at https://diffeqflux.sciml.ai/stable/Flux/#Using-Flux-Chain-neural-networks-with-Flux.train!-1
it had following missing lines, without which it would result in `UndefVarError: p not defined`
```
p,re = Flux.destructure(dudt2) # use this p as the initial condition!
dudt(u,p,t) = re(p)(u) # need to restrcture for backprop!
```