### PR TITLE
Fix & simplify multiple shooting (#522)

### DIFF
--- a/docs/src/examples/multiple_shooting.md
+++ b/docs/src/examples/multiple_shooting.md
@@ -78,7 +78,7 @@ group_size = 3
 continuity_term = 200
 
 function loss_function(data, pred)
-	return sum(abs2, data - pred)^2
+	return sum(abs2, data - pred)
 end
 
 function loss_multiple_shooting(p)

--- a/docs/src/examples/multiple_shooting.md
+++ b/docs/src/examples/multiple_shooting.md
@@ -7,11 +7,11 @@ then the joined/combined solution is same as solving on the whole dataset
 (without splitting).
 
 To ensure that the overlapping part of two consecutive intervals coincide,
-we add a penalizing term, `continuity_term * absolute_value_of( prediction
-of last point of some group, i - prediction of first point of group i+1 )`, to
+we add a penalizing term, `continuity_term * absolute_value_of(prediction
+of last point of group i - prediction of first point of group i+1)`, to
 the loss.
 
-Note that the `continuity_strength` should have a large positive value to add
+Note that the `continuity_term` should have a large positive value to add
 high penalties in case the solver predicts discontinuous values.
 
 
@@ -93,18 +93,16 @@ res_ms = DiffEqFlux.sciml_train(loss_multiple_shooting, res_ms.minimizer,
                                 BFGS(), cb = callback, maxiters = 100,
                                 allow_f_increases=true)
 
-# gif(anim, "multiple_shooting.gif", fps=15)
+gif(anim, "multiple_shooting.gif", fps=15)
 
 ```
-Here's the plots that we get from above
+Here's the animation that we get from above
 
-![pic](https://user-images.githubusercontent.com/58384989/111881194-6de9a480-89d5-11eb-8f21-6481d1e22521.PNG)
-The picture on the left shows how well our Neural Network does on a single shoot
-after training it through `multiple_shoot`.
-The picture on the right shows the predictions of each group (Notice that there
+![pic](https://camo.githubusercontent.com/9f1a4b38895ebaa47b7d90e53268e6f10d04da684b58549624c637e85c22d27b/68747470733a2f2f692e696d6775722e636f6d2f636d507a716a722e676966)
+The connected lines show the predictions of each group (Notice that there
 are overlapping points as well. These are the points we are trying to coincide.)
 
-Here is an output with `group_size` = 30 (which is same as solving on the whole
+Here is an output with `group_size = 30` (which is same as solving on the whole
 interval without splitting also called single shooting)
 
 ![pic_single_shoot3](https://user-images.githubusercontent.com/58384989/111843307-f0fff180-8926-11eb-9a06-2731113173bc.PNG)

--- a/docs/src/examples/multiple_shooting.md
+++ b/docs/src/examples/multiple_shooting.md
@@ -2,25 +2,26 @@
 
 In Multiple Shooting, the training data is split into overlapping intervals.
 The solver is then trained on individual intervals. If the end conditions of any
-interval co-incide with the initial conditions of the next immediate interval,
+interval coincide with the initial conditions of the next immediate interval,
 then the joined/combined solution is same as solving on the whole dataset
 (without splitting).
 
-To ensure that the overlapping part of two consecutive intervals co-incide,
-we add a penalizing term, `continuity_strength * absolute_value_of( prediction
+To ensure that the overlapping part of two consecutive intervals coincide,
+we add a penalizing term, `continuity_term * absolute_value_of( prediction
 of last point of some group, i - prediction of first point of group i+1 )`, to
 the loss.
 
 Note that the `continuity_strength` should have a large positive value to add
-high penalities in case the solver predicts discontinuous values.
+high penalties in case the solver predicts discontinuous values.
 
 
 The following is a working demo, using Multiple Shooting
 
 ```julia
 using DiffEqFlux, OrdinaryDiffEq, Flux, Optim, Plots
+using DiffEqFlux: group_ranges
 
-# Define initial conditions and timesteps
+# Define initial conditions and time steps
 datasize = 30
 u0 = Float32[2.0, 0.0]
 tspan = (0.0f0, 5.0f0)
@@ -37,68 +38,62 @@ ode_data = Array(solve(prob_trueode, Tsit5(), saveat = tsteps))
 
 
 # Define the Neural Network
-dudt2 = FastChain((x, p) -> x.^3,
+nn = FastChain((x, p) -> x.^3,
                   FastDense(2, 16, tanh),
                   FastDense(16, 2))
+p_init = initial_params(nn)
 
-prob_neuralode = NeuralODE(dudt2, (0.0,5.0), Tsit5(), saveat = tsteps)
+neuralode = NeuralODE(nn, tspan, Tsit5(), saveat = tsteps)
+prob_node = ODEProblem((u,p,t)->nn(u,p), u0, tspan, p_init)
 
-function plot_function_for_multiple_shoot(plt, pred, grp_size)
-	step = 1
-	if(grp_size != 1)
-		step = grp_size-1
-	end
-	if(grp_size == datasize)
-		scatter!(plt, tsteps, pred[1][1,:], label = "pred")
-	else
-		for i in 1:step:datasize-grp_size
-			# The term `trunc(Integer,(i-1)/(grp_size-1)+1)` goes from 1, 2, ... , N where N is the total number of groups that can be formed from `ode_data` (In other words, N = trunc(Integer, (datasize-1)/(grp_size-1)))
-			scatter!(plt, tsteps[i:i+step], pred[trunc(Integer,(i-1)/step+1)][1,:], label = "grp"*string(trunc(Integer,(i-1)/step+1)))
-		end
+
+function plot_multiple_shoot(plt, preds, group_size)
+	step = group_size-1
+	ranges = group_ranges(datasize, group_size)
+
+	for (i, rg) in enumerate(ranges)
+		plot!(plt, tsteps[rg], preds[i][1,:], markershape=:circle, label="Group $(i)")
 	end
 end
 
-callback = function (p, l, pred, predictions; doplot = true)
+# Animate training
+anim = Animation()
+callback = function (p, l, preds; doplot = true)
   display(l)
   if doplot
 	# plot the original data
-	plt = scatter(tsteps[1:size(pred,2)], ode_data[1,1:size(pred,2)], label = "data")
+	plt = scatter(tsteps[:], ode_data[1,:], label = "Data")
 
 	# plot the different predictions for individual shoot
-	plot_function_for_multiple_shoot(plt, predictions, grp_size_param)
+	plot_multiple_shoot(plt, preds, group_size)
 
-	# plot a single shooting performance of our multiple shooting training (this is what the solver predicts after the training is done)
-	# scatter!(plt, tsteps[1:size(pred,2)], pred[1,:], label = "pred")
-
+    frame(anim)
     display(plot(plt))
   end
   return false
 end
 
 # Define parameters for Multiple Shooting
-grp_size_param = 1
-loss_multiplier_param = 100
+group_size = 3
+continuity_term = 200
 
-neural_ode_f(u,p,t) = dudt2(u,p)
-prob_param = ODEProblem(neural_ode_f, u0, tspan, initial_params(dudt2))
-
-function loss_function_param(ode_data, pred):: Float32
-	return sum(abs2, (ode_data .- pred))^2
+function loss_function(data, pred)
+	return sum(abs2, data - pred)^2
 end
 
-function loss_neuralode(p)
-	return multiple_shoot(p, ode_data, tsteps, prob_param, loss_function_param, Tsit5(), grp_size_param, loss_multiplier_param)
+function loss_multiple_shooting(p)
+    return multiple_shoot(p, ode_data, tsteps, prob_node, loss_function, Tsit5(),
+                          group_size; continuity_term)
 end
 
-result_neuralode = DiffEqFlux.sciml_train(loss_neuralode, prob_neuralode.p,
-                                          ADAM(0.05), cb = callback,
-                                          maxiters = 300)
-callback(result_neuralode.minimizer,loss_neuralode(result_neuralode.minimizer)...;doplot=true)
+res_ms = DiffEqFlux.sciml_train(loss_multiple_shooting, p_init,
+                                ADAM(0.05), cb = callback, maxiters = 300)
 
-result_neuralode_2 = DiffEqFlux.sciml_train(loss_neuralode, result_neuralode.minimizer,
-                                          BFGS(), cb = callback,
-                                          maxiters = 100, allow_f_increases=true)
-callback(result_neuralode_2.minimizer,loss_neuralode(result_neuralode_2.minimizer)...;doplot=true)
+res_ms = DiffEqFlux.sciml_train(loss_multiple_shooting, res_ms.minimizer,
+                                BFGS(), cb = callback, maxiters = 100,
+                                allow_f_increases=true)
+
+# gif(anim, "multiple_shooting.gif", fps=15)
 
 ```
 Here's the plots that we get from above
@@ -109,7 +104,7 @@ after training it through `multiple_shoot`.
 The picture on the right shows the predictions of each group (Notice that there
 are overlapping points as well. These are the points we are trying to coincide.)
 
-Here is an output with `grp_size` = 30 (which is same as solving on the whole
+Here is an output with `group_size` = 30 (which is same as solving on the whole
 interval without splitting also called single shooting)
 
 ![pic_single_shoot3](https://user-images.githubusercontent.com/58384989/111843307-f0fff180-8926-11eb-9a06-2731113173bc.PNG)

--- a/docs/src/examples/multiple_shooting.md
+++ b/docs/src/examples/multiple_shooting.md
@@ -62,7 +62,7 @@ callback = function (p, l, preds; doplot = true)
   display(l)
   if doplot
 	# plot the original data
-	plt = scatter(tsteps[:], ode_data[1,:], label = "Data")
+	plt = scatter(tsteps, ode_data[1,:], label = "Data")
 
 	# plot the different predictions for individual shoot
 	plot_multiple_shoot(plt, preds, group_size)

--- a/src/multiple_shooting.jl
+++ b/src/multiple_shooting.jl
@@ -91,10 +91,10 @@ Arguments:
 
 Example:
 ```julia-repl
-julia> group_ranges(10, 4)
+julia> group_ranges(10, 5)
 3-element Vector{UnitRange{Int64}}:
- 1:4
- 5:8
+ 1:5
+ 5:9
  9:10
 ```
 """

--- a/src/multiple_shooting.jl
+++ b/src/multiple_shooting.jl
@@ -1,23 +1,28 @@
 """
-Returns the a total loss after trying a 'Direct multiple shooting' on ODE data, predictions on the whole ODE data and an array of predictions from the each of the groups (smaller intervals).
-In Direct Multiple Shooting, the Neural Network divides the interval into smaller intervals and solves for them separately.
-The default group size is 5 implying the whole dataset would be divided in groups of 5 and the Neural Network will solve on them individually.
-The default continuity term is 100 implying any losses arising from the non-continuity of 2 different groups will be scaled by 100.
+Returns the a total loss after trying a 'Direct multiple shooting' on ODE data
+and an array of predictions from the each of the groups (smaller intervals).
+In Direct Multiple Shooting, the Neural Network divides the interval into smaller intervals
+and solves for them separately.
+The default continuity term is 100 implying any losses arising from the non-continuity
+of 2 different groups will be scaled by 100.
 
 ```julia
-multiple_shoot(p,ode_data,tsteps,prob,loss_function,grp_size,continuity_strength=100)
+multiple_shoot(p, ode_data, tsteps, prob, loss_function, group_size; continuity_term=100)
 ```
-Arguments:
-- `p`: The parameters of the Neural Network to be trained.
-- `ode_data`: Original Data to be modelled.
-- `tsteps`: Timesteps on which ode_data was calculated.
-- `prob`: ODE problem that the Neural Network attempts to solve.
-- `loss_function`: Any arbitrary function to calculate loss.
-- `grp_size`: The group size achieved after splitting the ode_data into equal sizes.
-- `continuity_term`: Multiplying factor to ensure continuity of predictions throughout different groups.
 
-!!!note
-The parameter 'continuity_term' should be a relatively big number to enforce a large penalty whenever the last point of any group doesn't coincide with the first point of next group.
+Arguments:
+  - `p`: The parameters of the Neural Network to be trained.
+  - `ode_data`: Original Data to be modelled.
+  - `tsteps`: Timesteps on which ode_data was calculated.
+  - `prob`: ODE problem that the Neural Network attempts to solve.
+  - `loss_function`: Any arbitrary function to calculate loss.
+  - `group_size`: The group size achieved after splitting the ode_data into equal sizes.
+  - `continuity_term`: Multiplying factor to ensure continuity of predictions throughout
+    different groups.
+
+Note:
+The parameter 'continuity_term' should be a relatively big number to enforce a large penalty
+whenever the last point of any group doesn't coincide with the first point of next group.
 """
 function multiple_shoot(
     p::AbstractArray,

--- a/src/multiple_shooting.jl
+++ b/src/multiple_shooting.jl
@@ -99,11 +99,11 @@ julia> group_ranges(10, 4)
 ```
 """
 function group_ranges(datasize::Integer, groupsize::Integer)
-    1 <= groupsize <= datasize || throw(
+    2 <= groupsize <= datasize || throw(
         DomainError(
             groupsize,
-            "datasize must be positive and groupsize must to be within [1, datasize]",
+            "datasize must be positive and groupsize must to be within [2, datasize]",
         ),
     )
-    return [i:min(datasize, i + groupsize - 1) for i in 1:groupsize:datasize]
+    return [i:min(datasize, i + groupsize - 1) for i in 1:groupsize-1:datasize-1]
 end

--- a/test/multiple_shoot.jl
+++ b/test/multiple_shoot.jl
@@ -1,11 +1,14 @@
 using DiffEqFlux, OrdinaryDiffEq, Flux, Optim, Test
+using DiffEqFlux: group_ranges
 
-# General loss function to compare single shooting and multiple shooting predictions
-function general_loss_function(result_neuralode)
-	return sum(abs2, (ode_data[:,:] .- Array(prob_neuralode(u0, result_neuralode.minimizer)) ))
-end
+## Test group partitioning helper function
+@test group_ranges(10, 4) == [1:4, 4:7, 7:10]
+@test group_ranges(10, 5) == [1:5, 5:9, 9:10]
+@test group_ranges(10, 10) == [1:10]
+@test_throws DomainError group_ranges(10, 1)
+@test_throws DomainError group_ranges(10, 11)
 
-# Define initial conditions and timesteps
+## Define initial conditions and time steps
 datasize = 30
 u0 = Float32[2.0, 0.0]
 tspan = (0.0f0, 5.0f0)
@@ -20,63 +23,56 @@ prob_trueode = ODEProblem(trueODEfunc, u0, tspan)
 ode_data = Array(solve(prob_trueode, Tsit5(), saveat = tsteps))
 
 # Define the Neural Network
-dudt2 = FastChain((x, p) -> x.^3,
-                  FastDense(2, 16, tanh),
-                  FastDense(16, 2))
-prob_neuralode = NeuralODE(dudt2, (0.0,5.0), Tsit5(), saveat = tsteps)
+nn = FastChain((x, p) -> x.^3,
+                FastDense(2, 16, tanh),
+                FastDense(16, 2))
+p_init = initial_params(nn)
 
-function loss_neuralode(p)
-    pred = Array(prob_neuralode(u0, p))
-    loss = sum(abs2, (ode_data[:,1:size(pred,2)] .- pred))
-    return loss, pred
+neuralode = NeuralODE(nn, tspan, Tsit5(), saveat = tsteps)
+prob_node = ODEProblem((u,p,t)->nn(u,p), u0, tspan, p_init)
+
+function predict_single_shooting(p)
+    return Array(neuralode(u0, p))
 end
 
+# Define loss function
+function loss_function(data, pred)
+	return sum(abs2, data - pred)
+end
 
-result_neuralode = DiffEqFlux.sciml_train(loss_neuralode, prob_neuralode.p,
+## Evaluate Single Shooting
+function loss_single_shooting(p)
+    pred = predict_single_shooting(p)
+    l = loss_function(ode_data, pred)
+    return l, pred
+end
+
+res_single_shooting = DiffEqFlux.sciml_train(loss_single_shooting, neuralode.p,
                                           ADAM(0.05),
 										  maxiters = 300)
 
-single_shoot_loss = general_loss_function(result_neuralode)
-println("single_shoot_loss: ",single_shoot_loss)
+loss_ss, _ = loss_single_shooting(res_single_shooting.minimizer)
+println("Single shooting loss: $(loss_ss)")
 
-# Define parameters for Multiple Shooting
-grp_size_param = 1
-loss_multiplier_param = 100
+## Test Multiple Shooting
+group_size = 2
+continuity_term = 100
 
-neural_ode_f(u,p,t) = dudt2(u,p)
-prob_param = ODEProblem(neural_ode_f, u0, tspan, initial_params(dudt2))
-
-function loss_function_param(ode_data, pred):: Float32
-	return sum(abs2, (ode_data .- pred))^2
+function loss_multiple_shooting(p)
+    return multiple_shoot(p, ode_data, tsteps, prob_node, loss_function, Tsit5(),
+                          group_size; continuity_term)
 end
 
-function loss_neuralode_param(p)
-	return multiple_shoot(p, ode_data, tsteps, prob_param, loss_function_param, Tsit5(), grp_size_param, loss_multiplier_param)
-end
+res_ms = DiffEqFlux.sciml_train(loss_multiple_shooting, neuralode.p,
+                                ADAM(0.05), maxiters = 300)
 
+# Calculate single shooting loss with parameter from multiple_shoot training
+loss_ms, _ = loss_single_shooting(res_ms.minimizer)
+println("Multiple shooting loss: $(loss_ms)")
+@test loss_ms < loss_ss
 
-multiple_shoot_result_neuralode_1 = DiffEqFlux.sciml_train(loss_neuralode_param, prob_neuralode.p,
-                                          ADAM(0.05),
-                                          maxiters = 300)
-
-multiple_shoot_loss_1 = general_loss_function(multiple_shoot_result_neuralode_1)
-println("multiple_shoot_loss_1: ",multiple_shoot_loss_1)
-
-
-# test for grp_size = 1
-@test multiple_shoot_loss_1 < single_shoot_loss
-
-# test for grp_size = 5
-grp_size_param = 5
-multiple_shoot_result_neuralode_2 = DiffEqFlux.sciml_train(loss_neuralode_param, prob_neuralode.p,
-                                          ADAM(0.05),
-                                          maxiters = 300)
-
-multiple_shoot_loss_2 = general_loss_function(multiple_shoot_result_neuralode_2)
-println("multiple_shoot_loss_2: ",multiple_shoot_loss_2)
-
-@test multiple_shoot_loss_2 < single_shoot_loss
-
-# test for DomainErrors
-@test_throws DomainError multiple_shoot(prob_neuralode.p, ode_data, tsteps, prob_param, loss_function_param, Tsit5(), 0, loss_multiplier_param)
-@test_throws DomainError multiple_shoot(prob_neuralode.p, ode_data, tsteps, prob_param, loss_function_param, Tsit5(), datasize + 1, loss_multiplier_param)
+# Test for DomainErrors
+@test_throws DomainError multiple_shoot(p_init, ode_data, tsteps, prob_node,
+                                        loss_function, Tsit5(), 1)
+@test_throws DomainError multiple_shoot(p_init, ode_data, tsteps, prob_node,
+                                        loss_function, Tsit5(), datasize + 1)


### PR DESCRIPTION
## Fix indexing
As a mentioned in #522, the indexing happening in the comprehensions of `multiple_shoot` seemed error-prone. Additionally, the cases weren't necessary.

I've simplified the code by introducing a helper function `group_ranges` with matching tests. 
It splits a dataset of size `datasize` (e.g. 10)  into ranges of length `group_size` (e.g. 5):
```julia-repl
julia> group_ranges(10, 5)
3-element Vector{UnitRange{Int64}}:
 1:5
 5:9
 9:10
```
With these ranges, the predictions can be calculated in a comprehension as it was previously done.
As you can see in the last range, it now also makes sure that **no data gets discarded** in the last group, which previously wasn't the case.

##  Remove single shooting
I've also chosen to remove the single shooting prediction that was previously run at the end:
https://github.com/SciML/DiffEqFlux.jl/blob/ee4937f33148dfeb7b71914763b9b8b86c4dc094/src/multiple_shooting.jl#L58-L60

1. It slows down training
2. One use-case of multiple shooting is to avoid unstable dynamics by integrating over shorter timespans. This re-introduced that instability.

## Minimum group size
I've also chosen to set the minimum `group_size` to `>=2`. As far as I understand, using a size of 1, the solution is simply given as the initial condition`u0` in every group and nothing is learned.