### PR TITLE
Add solver kwargs to multiple shooting

### DIFF
--- a/src/multiple_shooting.jl
+++ b/src/multiple_shooting.jl
@@ -3,12 +3,14 @@ Returns the a total loss after trying a 'Direct multiple shooting' on ODE data
 and an array of predictions from the each of the groups (smaller intervals).
 In Direct Multiple Shooting, the Neural Network divides the interval into smaller intervals
 and solves for them separately.
-The default continuity term is 100 implying any losses arising from the non-continuity
+The default continuity term is 100, implying any losses arising from the non-continuity
 of 2 different groups will be scaled by 100.
 
 ```julia
-multiple_shoot(p, ode_data, tsteps, prob, loss_function, group_size; continuity_term=100)
-multiple_shoot(p, ode_data, tsteps, prob, loss_function, continuity_loss, group_size; continuity_term=100)
+multiple_shoot(p, ode_data, tsteps, prob, loss_function, solver, group_size;
+               continuity_term=100, sensealg=DiffEqSensitivity.InterpolatingAdjoint())
+multiple_shoot(p, ode_data, tsteps, prob, loss_function, continuity_loss, solver, group_size;
+               continuity_term=100, sensealg=DiffEqSensitivity.InterpolatingAdjoint())
 ```
 
 Arguments:
@@ -17,13 +19,17 @@ Arguments:
   - `tsteps`: Timesteps on which ode_data was calculated.
   - `prob`: ODE problem that the Neural Network attempts to solve.
   - `loss_function`: Any arbitrary function to calculate loss.
+  - `continuity_loss`: Function that takes states ``\\hat{u}_{end}`` of group ``k`` and
+  ``u_{0}`` of group ``k+1`` as input and calculates prediction continuity loss
+  between them.
+  If no custom `continuity_loss` is specified, `sum(abs, û_end - u_0)` is used.
+  - `solver`: ODE Solver algorithm.
   - `group_size`: The group size achieved after splitting the ode_data into equal sizes.
   - `continuity_term`: Weight term to ensure continuity of predictions throughout
   different groups.
-  - `continuity_loss`: Function that takes states ``\\hat{u}_{end}`` of group ``k`` and
-    ``u_{0}`` of group ``k+1`` as input and calculates prediction continuity loss
-    between them.
-    If no custom `continuity_loss` is specified, `sum(abs, û_end - u_0)` is used.
+  - `sensealg`: Sensitivity algorithm, defaults to `InterpolatingAdjoint()`. Refer to
+  the [Local Sensitivity Analysis](https://diffeq.sciml.ai/dev/analysis/sensitivity/)
+  documentation for more details.
 
 Note:
 The parameter 'continuity_term' should be a relatively big number to enforce a large penalty
@@ -39,6 +45,7 @@ function multiple_shoot(
     solver::DiffEqBase.AbstractODEAlgorithm,
     group_size::Integer;
     continuity_term::Real=100,
+    sensealg::SciMLBase.AbstractSensitivityAlgorithm=InterpolatingAdjoint(),
 )
     datasize = size(ode_data, 2)
 
@@ -61,6 +68,7 @@ function multiple_shoot(
                 ),
                 solver;
                 saveat=tsteps[rg],
+                sensealg=sensealg,
             ),
         ) for rg in ranges
     ]
@@ -91,7 +99,7 @@ function multiple_shoot(
     loss_function::Function,
     solver::DiffEqBase.AbstractODEAlgorithm,
     group_size::Integer;
-    continuity_term::Real=100,
+    kwargs...,
 )
     # Continuity loss between last state in previous prediction
     # and current initial condition in ode_data
@@ -108,7 +116,7 @@ function multiple_shoot(
         continuity_loss,
         solver,
         group_size;
-        continuity_term,
+        kwargs...,
     )
 end
 

--- a/src/multiple_shooting.jl
+++ b/src/multiple_shooting.jl
@@ -8,9 +8,9 @@ of 2 different groups will be scaled by 100.
 
 ```julia
 multiple_shoot(p, ode_data, tsteps, prob, loss_function, solver, group_size;
-               continuity_term=100, sensealg=DiffEqSensitivity.InterpolatingAdjoint())
+               continuity_term=100, kwargs...)
 multiple_shoot(p, ode_data, tsteps, prob, loss_function, continuity_loss, solver, group_size;
-               continuity_term=100, sensealg=DiffEqSensitivity.InterpolatingAdjoint())
+               continuity_term=100, kwargs...)
 ```
 
 Arguments:

--- a/src/multiple_shooting.jl
+++ b/src/multiple_shooting.jl
@@ -27,8 +27,9 @@ Arguments:
   - `group_size`: The group size achieved after splitting the ode_data into equal sizes.
   - `continuity_term`: Weight term to ensure continuity of predictions throughout
   different groups.
-  - `sensealg`: Sensitivity algorithm, defaults to `InterpolatingAdjoint()`. Refer to
-  the [Local Sensitivity Analysis](https://diffeq.sciml.ai/dev/analysis/sensitivity/)
+  - `kwargs`: Additional arguments splatted to the ODE solver. Refer to the
+  [Local Sensitivity Analysis](https://diffeq.sciml.ai/dev/analysis/sensitivity/) and
+  [Common Solver Arguments](https://diffeq.sciml.ai/dev/basics/common_solver_opts/)
   documentation for more details.
 
 Note:
@@ -45,7 +46,7 @@ function multiple_shoot(
     solver::DiffEqBase.AbstractODEAlgorithm,
     group_size::Integer;
     continuity_term::Real=100,
-    sensealg::SciMLBase.AbstractSensitivityAlgorithm=InterpolatingAdjoint(),
+    kwargs...
 )
     datasize = size(ode_data, 2)
 
@@ -68,7 +69,7 @@ function multiple_shoot(
                 ),
                 solver;
                 saveat=tsteps[rg],
-                sensealg=sensealg,
+                kwargs...
             ),
         ) for rg in ranges
     ]

--- a/test/multiple_shoot.jl
+++ b/test/multiple_shoot.jl
@@ -60,7 +60,8 @@ continuity_term = 200
 
 function loss_multiple_shooting(p)
     return multiple_shoot(p, ode_data, tsteps, prob_node, loss_function, Tsit5(),
-                          group_size; continuity_term)
+                          group_size; continuity_term,
+                          abstol=1e-3, reltol=1e-3) # test solver kwargs
 end
 
 res_ms = DiffEqFlux.sciml_train(loss_multiple_shooting, neuralode.p,

--- a/test/multiple_shoot.jl
+++ b/test/multiple_shoot.jl
@@ -1,4 +1,4 @@
-using DiffEqFlux, OrdinaryDiffEq, Flux, Optim, Test
+using DiffEqFlux, DiffEqSensitivity, OrdinaryDiffEq, Flux, Optim, Test
 using DiffEqFlux: group_ranges
 
 ## Test group partitioning helper function
@@ -92,7 +92,23 @@ loss_ms_abs2, _ = loss_single_shooting(res_ms_abs2.minimizer)
 println("Multiple shooting loss with abs2: $(loss_ms_abs2)")
 @test loss_ms_abs2 < loss_ss
 
-# Test for DomainErrors
+## Test different SensitivityAlgorithm (default is InterpolatingAdjoint)
+function loss_multiple_shooting_fd(p)
+    return multiple_shoot(p, ode_data, tsteps, prob_node,
+                          loss_function, continuity_loss_abs2, Tsit5(),
+                          group_size; continuity_term,
+                          sensealg=ForwardDiffSensitivity())
+end
+
+res_ms_fd = DiffEqFlux.sciml_train(loss_multiple_shooting_fd, neuralode.p,
+                                ADAM(0.05), maxiters = 300)
+
+# Calculate single shooting loss with parameter from multiple_shoot training
+loss_ms_fd, _ = loss_single_shooting(res_ms_fd.minimizer)
+println("Multiple shooting loss with ForwardDiffSensitivity: $(loss_ms_fd)")
+@test loss_ms_fd < loss_ss
+
+## Test for DomainErrors
 @test_throws DomainError multiple_shoot(p_init, ode_data, tsteps, prob_node,
                                         loss_function, Tsit5(), 1)
 @test_throws DomainError multiple_shoot(p_init, ode_data, tsteps, prob_node,


### PR DESCRIPTION
Allows setting `sensalg` and tolerances  when using `multiple_shoot`.