### PR TITLE
Update divergence.md

### DIFF
--- a/docs/src/examples/divergence.md
+++ b/docs/src/examples/divergence.md
@@ -66,5 +66,8 @@ end
 using DiffEqFlux
 
 pinit = [1.2,0.8,2.5,0.8]
-res = DiffEqFlux.sciml_train(loss,pinit,BFGS())
+res = DiffEqFlux.sciml_train(loss,pinit,ADAM(), maxiters = 1000)
+
+#try Newton method of optimization
+res = DiffEqFlux.sciml_train(loss,pinit,Newton(), GalacticOptim.AutoForwardDiff())
 ```


### PR DESCRIPTION
The previous example wouldn't run. The issue arises because Zygote returns `nothing` and the cache used by Optim for gradient result thus throws a convert error, this can be handled in GalacticOptim but I wonder if it's worth it, will create an issue there to track. 