### PR TITLE
Update bouncing_ball.md ReverseDiffAdjoint example

### DIFF
--- a/docs/src/examples/bouncing_ball.md
+++ b/docs/src/examples/bouncing_ball.md
@@ -75,6 +75,8 @@ that version we showcased forward sensitivity analysis, but adjoints
 can be utilized as well:
 
 ```julia
+using ReverseDiff
+
 function loss(θ)
   sol = solve(prob,Tsit5(),p=[9.8,θ[1]],callback=cb,sensealg=ReverseDiffAdjoint())
   target = 20.0


### PR DESCRIPTION
Since ReverseDiff is behind `requires` in DiffEqBase to load `DiffEqBase.value` dispatch for `ReverseDiff.TrackedReal`in the `stepsize_controller` function in OrdinaryDiffEq. 