### PR TITLE
Use return codes in multiple shooting

### DIFF
--- a/test/multiple_shoot.jl
+++ b/test/multiple_shoot.jl
@@ -111,9 +111,8 @@ println("Multiple shooting loss with ForwardDiffSensitivity: $(loss_ms_fd)")
 
 # Integration return codes `!= :Success` should return infinite loss.
 # In this case, we trigger `retcode = :MaxIters` by setting the solver option `maxiters=1`.
-# Therefore `Warning: Interrupted. Larger maxiters is needed.` is intended here!
 loss_fail, _ = multiple_shoot(p_init, ode_data, tsteps, prob_node, loss_function, Tsit5(),
-                              datasize; maxiters=1)
+                              datasize; maxiters=1, verbose=false)
 @test loss_fail == Inf
 
 ## Test for DomainErrors

--- a/test/multiple_shoot.jl
+++ b/test/multiple_shoot.jl
@@ -109,6 +109,13 @@ loss_ms_fd, _ = loss_single_shooting(res_ms_fd.minimizer)
 println("Multiple shooting loss with ForwardDiffSensitivity: $(loss_ms_fd)")
 @test loss_ms_fd < loss_ss
 
+# Integration return codes `!= :Success` should return infinite loss.
+# In this case, we trigger `retcode = :MaxIters` by setting the solver option `maxiters=1`.
+# Therefore `Warning: Interrupted. Larger maxiters is needed.` is intended here!
+loss_fail, _ = multiple_shoot(p_init, ode_data, tsteps, prob_node, loss_function, Tsit5(),
+                              datasize; maxiters=1)
+@test loss_fail == Inf
+
 ## Test for DomainErrors
 @test_throws DomainError multiple_shoot(p_init, ode_data, tsteps, prob_node,
                                         loss_function, Tsit5(), 1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,6 +33,7 @@ if GROUP == "All" || GROUP == "DiffEqFlux" || GROUP == "BasicNeuralDE"
     @safetestset "Fast Neural ODE Tests" begin include("fast_neural_ode.jl") end
     @safetestset "Tensor Product Layer" begin include("tensor_product_test.jl") end
     @safetestset "Spline Layer" begin include("spline_layer_test.jl") end
+    @safetestset "Multiple shooting" begin include("multiple_shoot.jl") end
 end
 
 if GROUP == "All" || GROUP == "AdvancedNeuralDE"


### PR DESCRIPTION
Previously, failure of integration of one of the groups in multiple shooting (e.g. due to `:DtLessThanMin`) lead to an interruption of training as there would be a dimension mismatch between the training data and the prediction.
 
## Changes
1. In this PR,  infinite loss is returned on failure of integration by using the solution return codes. 
    I wasn't sure how to add tests for this, so let me know if you have an idea.

1. I also included `test/multiple_shoot.jl` in `test/runtest.jl`, as the tests previously weren't run in CI. I wasn't sure which section to include them in, so you might want to change this.