### PR TITLE
Remove unfinished sentence in sciml_train docs

### DIFF
--- a/docs/src/sciml_train.md
+++ b/docs/src/sciml_train.md
@@ -2,7 +2,7 @@
 
 `sciml_train` is a heuristic-based training function built using GalacticOptim.jl.
 It incorporates the knowledge of many high level benchmarks to attempt and do
-the right thing. However, if you need more control,
+the right thing.
 
 GalacticOptim.jl is a package with a scope that is beyond your normal global optimization
 package. GalacticOptim.jl seeks to bring together all of the optimization packages


### PR DESCRIPTION
The first paragraph of the manual docs for `sciml_train` - [sciml_train.md](https://github.com/SciML/DiffEqFlux.jl/blob/master/docs/src/sciml_train.md) - has an unfinished sentence at the end:

> `sciml_train` is a heuristic-based training function built using GalacticOptim.jl. It incorporates the knowledge of many high level benchmarks to attempt and do the right thing. However, if you need more control,

From the contents of [this example](docs/src/examples/neural_ode_galacticoptim.md) I am guessing that the whole sentence was copied accidentally and can be removed.