### PR TITLE
Fix differences between full code and documented code in CNF example

### DIFF
--- a/docs/src/examples/mnist_conv_neural_ode.md
+++ b/docs/src/examples/mnist_conv_neural_ode.md
@@ -364,7 +364,7 @@ for Neural ODE is given by `nn_ode.p`:
 
 ```julia
 # Train the NN-ODE and monitor the loss and weights.
-Flux.train!(loss, params(down, nn_ode.p, fc), train_dataloader, opt, cb = cb)
+Flux.train!(loss, Flux.params(down, nn_ode.p, fc), train_dataloader, opt, cb = cb)
 ```
 
 ### Expected Output

--- a/docs/src/examples/mnist_neural_ode.md
+++ b/docs/src/examples/mnist_neural_ode.md
@@ -114,7 +114,7 @@ cb() = begin
 end
 
 # Train the NN-ODE and monitor the loss and weights.
-Flux.train!(loss, params(down, nn_ode.p, fc), train_dataloader, opt, cb = cb)
+Flux.train!(loss, Flux.params(down, nn_ode.p, fc), train_dataloader, opt, cb = cb)
 ```
 
 

--- a/test/ensembles.jl
+++ b/test/ensembles.jl
@@ -24,7 +24,7 @@ end
 opt = ADAM(0.1)
 println("Starting to train")
 l1 = loss()
-Flux.@epochs 10 Flux.train!(loss, params([pa,u0]), data, opt; cb = cb)
+Flux.@epochs 10 Flux.train!(loss, Flux.params([pa,u0]), data, opt; cb = cb)
 l2 = loss()
 @test 10l2 < l1
 
@@ -45,7 +45,7 @@ u0 = [3.0]
 opt = ADAM(0.1)
 println("Starting to train")
 l1 = loss()
-Flux.@epochs 10 Flux.train!(loss, params([pa,u0]), data, opt; cb = cb)
+Flux.@epochs 10 Flux.train!(loss, Flux.params([pa,u0]), data, opt; cb = cb)
 l2 = loss()
 @test 10l2 < l1
 
@@ -74,6 +74,6 @@ u0 = [3.0]
 opt = ADAM(0.1)
 println("Starting to train")
 l1 = loss()
-Flux.@epochs 10 Flux.train!(loss, params([pa,u0]), data, opt; cb = cb)
+Flux.@epochs 10 Flux.train!(loss, Flux.params([pa,u0]), data, opt; cb = cb)
 l2 = loss()
 @test 10l2 < l1

--- a/test/mnist_gpu.jl
+++ b/test/mnist_gpu.jl
@@ -97,5 +97,5 @@ cb() = begin
 end
 
 # Train the NN-ODE and monitor the loss and weights.
-Flux.train!( loss, params( down, nn_ode.p, fc), zip( x_train, y_train ), opt, cb = cb )
+Flux.train!( loss, Flux.params( down, nn_ode.p, fc), zip( x_train, y_train ), opt, cb = cb )
 @test accuracy(m, zip(x_train,y_train)) > 0.8


### PR DESCRIPTION
There are differences between full code and documented code in CNF example, I fixed it and also changed some part of it.  In addition, I added an evaluation section to demonstrate how to use the model and compare it to actual pdf.

I saw this warning:
```julia
WARNING: both Flux and Distributions export "params"; uses of it in module DiffEqFlux must be qualified
```
So, I made them be qualified.
