### PR TITLE
use `DiagNormal` instead of `FullNormal` 

### DIFF
--- a/src/ffjord.jl
+++ b/src/ffjord.jl
@@ -50,7 +50,8 @@ struct DeterministicCNF{M,P,RE,Distribution,T,A,K} <: CNFLayer
         end
         if basedist === nothing
             size_input = size(model[1].weight, 2)
-            basedist = MvNormal(zeros(size_input), I + zeros(size_input, size_input))
+            type_input = eltype(model[1].weight)
+            basedist = MvNormal(zeros(type_input, size_input), Diagonal(ones(type_input, size_input)))
         end
         @warn("This layer has been deprecated in favor of `FFJORD`. Use FFJORD with `monte_carlo=false` instead.")
         new{typeof(model),typeof(p),typeof(re),typeof(basedist),typeof(tspan),typeof(args),typeof(kwargs)}(
@@ -127,7 +128,8 @@ struct FFJORD{M,P,RE,Distribution,T,A,K} <: CNFLayer
         end
         if basedist === nothing
             size_input = size(model[1].weight, 2)
-            basedist = MvNormal(zeros(size_input), I + zeros(size_input, size_input))
+            type_input = eltype(model[1].weight)
+            basedist = MvNormal(zeros(type_input, size_input), Diagonal(ones(type_input, size_input)))
         end
         new{typeof(model),typeof(p),typeof(re),typeof(basedist),typeof(tspan),typeof(args),typeof(kwargs)}(
             model, p, re, basedist, tspan, args, kwargs)

--- a/src/ffjord.jl
+++ b/src/ffjord.jl
@@ -159,7 +159,7 @@ function jacobian_fn(f, x::AbstractMatrix)
 _trace_batched(x::AbstractArray{T,3}) where T =
     reshape([tr(x[:, :, i]) for i in 1:size(x, 3)], 1, size(x, 3))
 
-function ffjord(u, p, t, re, e=randn(eltype(x), size(x));
+function ffjord(u, p, t, re, e;
                 regularize=false, monte_carlo=true)
     m = re(p)
     if regularize


### PR DESCRIPTION
I just made `FFJORD` use `DiagNormal` instead of `FullNormal` and also made it use a type as same as the neural network
I fixed a default value mistake that caused by copy-paste (that's my mistake in #597, but because the only use of this function has a value, it can't make any error)