### PR TITLE
Remove type promotion in FFJORD

### DIFF
--- a/src/ffjord.jl
+++ b/src/ffjord.jl
@@ -221,8 +221,7 @@ function forward_ffjord(n::FFJORD, x, p=n.p, e=randn(eltype(x), size(x));
         λ₁ = λ₂ = _z[1, :]
     end
 
-    # logpdf promotes the type to Float64 by default
-    logpz = eltype(x).(reshape(logpdf(pz, z), 1, size(x, 2)))
+    logpz = reshape(logpdf(pz, z), 1, size(x, 2))
     logpx = logpz .- delta_logp
 
     logpx, λ₁, λ₂

--- a/test/cnf_test.jl
+++ b/test/cnf_test.jl
@@ -40,13 +40,13 @@ end
             regularize = false
             monte_carlo = false
 
-            @test_broken !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; cb, maxiters=10))
+            @test !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; cb, maxiters=10))
         end
         @testset "regularize=false & monte_carlo=true" begin
             regularize = false
             monte_carlo = true
 
-            @test_broken !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; cb, maxiters=10))
+            @test !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; cb, maxiters=10))
         end
         @testset "regularize=true & monte_carlo=false" begin
             regularize = true
@@ -58,7 +58,7 @@ end
             regularize = true
             monte_carlo = true
 
-            @test_broken !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; cb, maxiters=10))
+            @test !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; cb, maxiters=10))
         end
     end
     @testset "AutoReverseDiff as adtype" begin


### PR DESCRIPTION
I tried to fix the ReverseDiff issue (#615) with FFJORD by removing the type promotion, but questionably it fixed the ForwardDiff issue (#610).
Now, output type of ffjord is as input type because of #617, I guess. So we don't need to promote the output of `logpdf` anymore.

Fixes #610