### PR TITLE
Added Scalar dispatch for FastDense

### DIFF
--- a/src/fast_layers.jl
+++ b/src/fast_layers.jl
@@ -127,7 +127,8 @@ ZygoteRules.@adjoint function (f::FastDense)(x::Number,p)
       end
       ifgpufree(Wbar)
       ifgpufree(r)
-      nothing,xbar,pbar
+      xb = xbar[1,1]
+      nothing,xb,pbar
     else
       if typeof(f.σ) <: typeof(NNlib.tanh_fast)
         @view(f.cache.zbar[:,1]) .= ȳ .* (1 .- (f.cache.yvec).^2)

--- a/src/fast_layers.jl
+++ b/src/fast_layers.jl
@@ -72,6 +72,87 @@ struct FastDense{F,F2,C} <: FastLayer
   end
 end
 
+# To work with scalars(x::Number)
+(f::FastDense)(x::Number,p) = ((f.bias == true) ? (f.σ.(reshape(p[1:(f.out*f.in)],f.out,f.in)*x .+ p[(f.out*f.in+1):end])) : (f.σ.(reshape(p[1:(f.out*f.in)],f.out,f.in)*x)))
+
+ZygoteRules.@adjoint function (f::FastDense)(x::Number,p)
+  if typeof(f.cache) <: Nothing
+    if !isgpu(p)
+      W = @view(p[reshape(1:(f.out*f.in),f.out,f.in)])
+    else
+      W = reshape(@view(p[1:(f.out*f.in)]),f.out,f.in)
+    end
+    if f.bias == true
+      b = p[(f.out*f.in + 1):end]
+      r = W*x .+ b
+      ifgpufree(b)
+    else
+      r = W*x
+    end
+    y = f.σ.(r)
+  else
+    if !isgpu(p)
+      f.cache.W .= @view(p[reshape(1:(f.out*f.in),f.out,f.in)])
+    else
+      f.cache.W .= reshape(@view(p[1:(f.out*f.in)]),f.out,f.in)
+    end
+    mul!(@view(f.cache.r[:,1]), f.cache.W, x)
+    if f.bias == true
+      # @view(f.cache.r[:,1]) .+= @view(p[(f.out*f.in + 1):end])
+      b = @view(p[(f.out*f.in + 1):end])
+      @view(f.cache.r[:,1]) .+= b
+    end
+    f.cache.yvec .= f.σ.(@view(f.cache.r[:,1]))
+  end
+  function FastDense_adjoint(ȳ)
+    if typeof(f.cache) <: Nothing
+      if typeof(f.σ) <: typeof(NNlib.tanh_fast)
+        zbar = ȳ .* (1 .- y.^2)
+      elseif typeof(f.σ) <: typeof(identity)
+        zbar = ȳ
+      else
+        zbar = ȳ .* ForwardDiff.derivative.(f.σ,r)
+      end
+      Wbar = zbar * x'
+      bbar = zbar
+      xbar = W' * zbar
+      pbar = if f.bias == true
+          tmp = typeof(bbar) <: AbstractVector ?
+                           vec(vcat(vec(Wbar),bbar)) :
+                           vec(vcat(vec(Wbar),sum(bbar,dims=2)))
+          ifgpufree(bbar)
+          tmp
+      else
+          vec(Wbar)
+      end
+      ifgpufree(Wbar)
+      ifgpufree(r)
+      nothing,xbar,pbar
+    else
+      if typeof(f.σ) <: typeof(NNlib.tanh_fast)
+        @view(f.cache.zbar[:,1]) .= ȳ .* (1 .- (f.cache.yvec).^2)
+      elseif typeof(f.σ) <: typeof(identity)
+        @view(f.cache.zbar[:,1]) .= ȳ
+      else
+        @view(f.cache.zbar[:,1]) .= ȳ .* ForwardDiff.derivative.(f.σ, @view(f.cache.r[:,1]))
+      end
+      mul!(f.cache.Wbar, @view(f.cache.zbar[:,1]), x')
+      mul!(@view(f.cache.xbar[:,1]), f.cache.W', @view(f.cache.zbar[:,1]))
+      f.cache.pbar .= if f.bias == true
+        vec(vcat(vec(f.cache.Wbar),@view(f.cache.zbar[:,1])))# bbar = zbar
+      else
+        vec(f.cache.Wbar)
+      end
+      nothing,@view(f.cache.xbar[:,1]),f.cache.pbar
+    end
+  end
+  if typeof(f.cache) <: Nothing
+    y,FastDense_adjoint
+  else
+    f.cache.yvec,FastDense_adjoint
+  end
+end
+
 # (f::FastDense)(x,p) = f.σ.(reshape(uview(p,1:(f.out*f.in)),f.out,f.in)*x .+ uview(p,(f.out*f.in+1):lastindex(p)))
 (f::FastDense)(x::AbstractVector,p) = ((f.bias == true) ? (f.σ.(reshape(p[1:(f.out*f.in)],f.out,f.in)*x .+ p[(f.out*f.in+1):end])) : (f.σ.(reshape(p[1:(f.out*f.in)],f.out,f.in)*x)))
 

--- a/src/fast_layers.jl
+++ b/src/fast_layers.jl
@@ -143,7 +143,8 @@ ZygoteRules.@adjoint function (f::FastDense)(x::Number,p)
       else
         vec(f.cache.Wbar)
       end
-      nothing,@view(f.cache.xbar[:,1]),f.cache.pbar
+      xbar = f.cache.xbar[1,1]
+      nothing,xbar,f.cache.pbar
     end
   end
   if typeof(f.cache) <: Nothing

--- a/test/fast_layers.jl
+++ b/test/fast_layers.jl
@@ -50,6 +50,16 @@ fdcgrad = Flux.Zygote.gradient((x,p)->sum(fdc(x,p)),x,pd)
 @allocated(Zygote.pullback(fdc, x, pd))
 @test @allocated(Zygote.pullback(fdc, x, pd)) < 1450
 
+#gradient test between pre-cached layer with scalar i/p and uncached vector i/p layer
+fdsclr = FastDense(1, 2, precache=true)
+pdsc = initial_params(fdsclr)
+x1 = 2
+fdvec = FastDense(1, 2)
+x2 = [2]
+fdsclrgrad = Zygote.pullback(fdsclr, x1, pdsc)
+fdvecgrad = Zygote.pullback(fdvec, x2, pdsc)
+@test fdsclrgrad[1] ≈ fdvecgrad[1] rtol=1e-6
+
 # Now test vs Zygote
 struct TestDense{F,F2} <: DiffEqFlux.FastLayer
   out::Int

--- a/test/fast_layers.jl
+++ b/test/fast_layers.jl
@@ -50,14 +50,17 @@ fdcgrad = Flux.Zygote.gradient((x,p)->sum(fdc(x,p)),x,pd)
 @allocated(Zygote.pullback(fdc, x, pd))
 @test @allocated(Zygote.pullback(fdc, x, pd)) < 1450
 
-#gradient test between pre-cached layer with scalar i/p and uncached vector i/p layer
 fdsclr = FastDense(1, 2, precache=true)
+fduc = FastDense(1, 2)
 pdsc = initial_params(fdsclr)
 x1 = 2.0
 fdvec = FastDense(1, 2)
 x2 = [2.]
 fdsclrgrad = Flux.Zygote.gradient((x,p)->sum(fdsclr(x,p)),x1,pdsc)
+fducgrad = Flux.Zygote.gradient((x,p)->sum(fduc(x,p)),x1,pdsc)
 fdvecgrad = Flux.Zygote.gradient((x,p)->sum(fdvec(x,p)),x2,pdsc)
+@test fdsclrgrad[1] ≈ fducgrad[1] rtol=1e-12
+@test fdsclrgrad[2] ≈ fducgrad[2] rtol=1e-12
 @test fdsclrgrad[1] ≈ fdvecgrad[1][1] rtol=1e-12
 @test fdsclrgrad[2] ≈ fdvecgrad[2] rtol=1e-12
 

--- a/test/fast_layers.jl
+++ b/test/fast_layers.jl
@@ -53,12 +53,13 @@ fdcgrad = Flux.Zygote.gradient((x,p)->sum(fdc(x,p)),x,pd)
 #gradient test between pre-cached layer with scalar i/p and uncached vector i/p layer
 fdsclr = FastDense(1, 2, precache=true)
 pdsc = initial_params(fdsclr)
-x1 = 2
+x1 = 2.0
 fdvec = FastDense(1, 2)
-x2 = [2]
-fdsclrgrad = Zygote.pullback(fdsclr, x1, pdsc)
-fdvecgrad = Zygote.pullback(fdvec, x2, pdsc)
-@test fdsclrgrad[1] ≈ fdvecgrad[1] rtol=1e-6
+x2 = [2.]
+fdsclrgrad = Flux.Zygote.gradient((x,p)->sum(fdsclr(x,p)),x1,pdsc)
+fdvecgrad = Flux.Zygote.gradient((x,p)->sum(fdvec(x,p)),x2,pdsc)
+@test fdsclrgrad[1] ≈ fdvecgrad[1][1] rtol=1e-12
+@test fdsclrgrad[2] ≈ fdvecgrad[2] rtol=1e-12
 
 # Now test vs Zygote
 struct TestDense{F,F2} <: DiffEqFlux.FastLayer


### PR DESCRIPTION
This branch adds a dispatch for computation with scalar input to FastDense Layers and a test for the same. Everything is computed accurately, although when I ran(for implementing a gradient test):

    fdsclr = FastDense(1, 2, precache=true)
    pdsc = initial_params(fdsclr)
    x1 = 2
    fdvec = FastDense(1, 2)
    x2 = [2]
    fdsclrgrad = Flux.Zygote.gradient((x,p)->sum(fdsclr(x,p)),x1,pdsc)

It throws an error which goes:

     MethodError: no method matching (::ChainRulesCore.ProjectTo{Float64, NamedTuple{(), Tuple{}}}) 
     (::SubArray{Float64, 1, Matrix{Float64}, Tuple{Base.Slice{Base.OneTo{Int64}}, Int64}, true})

      Closest candidates are:
      (::ChainRulesCore.ProjectTo)(!Matched::ChainRulesCore.Thunk) at
      C:\Users\user\.julia\packages\ChainRulesCore\uxrij\src\projection.jl:124
     (::ChainRulesCore.ProjectTo{T})(!Matched::Integer) where T<:AbstractFloat at 
     C:\Users\user\.julia\packages\ChainRulesCore\uxrij\src\projection.jl:171
     (::ChainRulesCore.ProjectTo{T})(!Matched::ChainRulesCore.AbstractZero) where T at 
      C:\Users\user\.julia\packages\ChainRulesCore\uxrij\src\projection.jl:120
       ...
      in eval at [base\boot.jl:373](https://github.com/SciML/DiffEqFlux.jl/compare/master...Abhishek-1Bhatt:FDscalar expand=1#) 
      in top-level scope at [diffeqtst2.jl:11](https://github.com/SciML/DiffEqFlux.jl/compare/master...Abhishek-1Bhatt:FDscalar?expand=1#)
      in gradient at [Zygote\FPUm3\src\compiler\interface.jl:77] 
      (https://github.com/SciML/DiffEqFlux.jl/compare/master...Abhishek-1Bhatt:FDscalar?expand=1#)
       in map at [base\tuple.jl:247](https://github.com/SciML/DiffEqFlux.jl/compare/master...Abhishek-1Bhatt:FDscalar?expand=1#)
       in _project at [Zygote\FPUm3\src\compiler\chainrules.jl:182] 
       (https://github.com/SciML/DiffEqFlux.jl/compare/master...Abhishek-1Bhatt:FDscalar?expand=1#)

Thus I added the test as:

(https://github.com/Abhishek-1Bhatt/DiffEqFlux.jl/blob/c2791017b8c5b27095f424cdb69a2e0026e1f310/test/fast_layers.jl#L54-L61)

Would this be a problem?