### PR TITLE
Update neural_de tests

### DIFF
--- a/test/neural_de.jl
+++ b/test/neural_de.jl
@@ -139,10 +139,19 @@ grads = Zygote.gradient(()->sum(node(xs)),Flux.params(xs,node))
 goodgrad2 = grads[node.p]
 @test goodgradc ≈ goodgrad2 rtol=1e-6
 
-node = NeuralODE(staticdudt,tspan,Tsit5(),save_everystep=false,save_start=false,sensealg=BacksolveAdjoint(),p=p)
+node = NeuralODE(staticdudt,tspan,Tsit5(),save_everystep=false,save_start=false,sensealg=BacksolveAdjoint(autojacvec=false),p=p)
 grads = Zygote.gradient(()->sum(node(x)),Flux.params(x,node))
 @test ! iszero(grads[x])
 @test ! iszero(grads[node.p])
+
+grads = Zygote.gradient(()->sum(node(xs)),Flux.params(xs,node))
+goodgrad2 = grads[node.p]
+@test goodgrad ≈ goodgrad2 rtol = 1e-6
+
+node = NeuralODE(staticdudt,tspan,Tsit5(),save_everystep=false,save_start=false,sensealg=BacksolveAdjoint(autojacvec=ZygoteVJP()),p=p)
+grads = Zygote.gradient(()->sum(node(x)),Flux.params(x,node))
+@test !iszero(grads[x])
+@test !iszero(grads[node.p])
 
 @test_throws ErrorException grads = Zygote.gradient(()->sum(node(xs)),Flux.params(xs,node))
 


### PR DESCRIPTION
When we change the default `sensealg` choice to a fallback to a numerical vjp (see https://github.com/SciML/DiffEqSensitivity.jl/pull/553), no ExceptionError in 

https://github.com/SciML/DiffEqFlux.jl/blob/9f648dc7ee51f0757768e587fe5b6763b34d30d6/test/neural_de.jl#L147

will be thrown. The previous default choice `ZygoteVJP()` did not work and erred with https://github.com/SciML/DiffEqFlux.jl/blob/9f648dc7ee51f0757768e587fe5b6763b34d30d6/src/fast_layers.jl#L386  `ZygoteVJP()` still does not work and throws the error as expected, see updated tests, but a correct gradient will be computed by the fallback (`autojacvec=false`) (with a warning that the vjp was changed.). 