### PR TITLE
just remove staticdudt tests

### DIFF
--- a/test/cnf_test.jl
+++ b/test/cnf_test.jl
@@ -293,7 +293,7 @@ end
 
     function loss(θ)
         logpx, λ₁, λ₂ = ffjord_mdl(train_data, θ; regularize, monte_carlo)
-        mean(-logpx .+ 0.1 * λ₁ .+ 0.1 * λ₂)
+        mean(-logpx .+ 1f-1 * λ₁ .+ 1f-1 * λ₂)
     end
 
     adtype = Optimization.AutoZygote()

--- a/test/cnf_test.jl
+++ b/test/cnf_test.jl
@@ -31,25 +31,25 @@ end
             regularize = false
             monte_carlo = false
 
-            @test !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; callback = callback, maxiters=10))
+            @test !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(1f-1), adtype; callback = callback, maxiters=10))
         end
         @testset "regularize=false & monte_carlo=true" begin
             regularize = false
             monte_carlo = true
 
-            @test !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; callback = callback, maxiters=10))
+            @test !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(1f-1), adtype; callback = callback, maxiters=10))
         end
         @testset "regularize=true & monte_carlo=false" begin
             regularize = true
             monte_carlo = false
 
-            @test_broken !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; callback = callback, maxiters=10))
+            @test_broken !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(1f-1), adtype; callback = callback, maxiters=10))
         end
         @testset "regularize=true & monte_carlo=true" begin
             regularize = true
             monte_carlo = true
 
-            @test !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; callback = callback, maxiters=10))
+            @test !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(1f-1), adtype; callback = callback, maxiters=10))
         end
     end
     @testset "AutoReverseDiff as adtype" begin
@@ -59,25 +59,25 @@ end
             regularize = false
             monte_carlo = false
 
-            @test_broken !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; callback = callback, maxiters=10))
+            @test_broken !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(1f-1), adtype; callback = callback, maxiters=10))
         end
         @testset "regularize=false & monte_carlo=true" begin
             regularize = false
             monte_carlo = true
 
-            @test_broken !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; callback = callback, maxiters=10))
+            @test_broken !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(1f-1), adtype; callback = callback, maxiters=10))
         end
         @testset "regularize=true & monte_carlo=false" begin
             regularize = true
             monte_carlo = false
 
-            @test_broken !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; callback = callback, maxiters=10))
+            @test_broken !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(1f-1), adtype; callback = callback, maxiters=10))
         end
         @testset "regularize=true & monte_carlo=true" begin
             regularize = true
             monte_carlo = true
 
-            @test_broken !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; callback = callback, maxiters=10))
+            @test_broken !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(1f-1), adtype; callback = callback, maxiters=10))
         end
     end
     @testset "AutoTracker as adtype" begin
@@ -87,25 +87,25 @@ end
             regularize = false
             monte_carlo = false
 
-            @test_broken !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; callback = callback, maxiters=10))
+            @test_broken !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(1f-1), adtype; callback = callback, maxiters=10))
         end
         @testset "regularize=false & monte_carlo=true" begin
             regularize = false
             monte_carlo = true
 
-            @test_broken !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; callback = callback, maxiters=10))
+            @test_broken !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(1f-1), adtype; callback = callback, maxiters=10))
         end
         @testset "regularize=true & monte_carlo=false" begin
             regularize = true
             monte_carlo = false
 
-            @test_broken !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; callback = callback, maxiters=10))
+            @test_broken !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(1f-1), adtype; callback = callback, maxiters=10))
         end
         @testset "regularize=true & monte_carlo=true" begin
             regularize = true
             monte_carlo = true
 
-            @test_broken !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; callback = callback, maxiters=10))
+            @test_broken !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(1f-1), adtype; callback = callback, maxiters=10))
         end
     end
     @testset "AutoZygote as adtype" begin
@@ -115,25 +115,25 @@ end
             regularize = false
             monte_carlo = false
 
-            @test !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; callback = callback, maxiters=10))
+            @test !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(1f-1), adtype; callback = callback, maxiters=10))
         end
         @testset "regularize=false & monte_carlo=true" begin
             regularize = false
             monte_carlo = true
 
-            @test !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; callback = callback, maxiters=10))
+            @test !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(1f-1), adtype; callback = callback, maxiters=10))
         end
         @testset "regularize=true & monte_carlo=false" begin
             regularize = true
             monte_carlo = false
 
-            @test_broken !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; callback = callback, maxiters=10))
+            @test_broken !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(1f-1), adtype; callback = callback, maxiters=10))
         end
         @testset "regularize=true & monte_carlo=true" begin
             regularize = true
             monte_carlo = true
 
-            @test !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; callback = callback, maxiters=10))
+            @test !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(1f-1), adtype; callback = callback, maxiters=10))
         end
     end
     @testset "AutoFiniteDiff as adtype" begin
@@ -143,25 +143,25 @@ end
             regularize = false
             monte_carlo = false
 
-            @test !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; callback = callback, maxiters=10))
+            @test !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(1f-1), adtype; callback = callback, maxiters=10))
         end
         @testset "regularize=false & monte_carlo=true" begin
             regularize = false
             monte_carlo = true
 
-            @test !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; callback = callback, maxiters=10))
+            @test !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(1f-1), adtype; callback = callback, maxiters=10))
         end
         @testset "regularize=true & monte_carlo=false" begin
             regularize = true
             monte_carlo = false
 
-            @test_broken !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; callback = callback, maxiters=10))
+            @test_broken !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(1f-1), adtype; callback = callback, maxiters=10))
         end
         @testset "regularize=true & monte_carlo=true" begin
             regularize = true
             monte_carlo = true
 
-            @test !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; callback = callback, maxiters=10))
+            @test !isnothing(DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(1f-1), adtype; callback = callback, maxiters=10))
         end
     end
 end
@@ -185,7 +185,7 @@ end
     regularize = false
     monte_carlo = false
 
-    res = DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(0.1), adtype; callback= callback, maxiters=10)
+    res = DiffEqFlux.sciml_train(θ -> loss(θ; regularize, monte_carlo), ffjord_mdl.p, ADAM(1f-1), adtype; callback= callback, maxiters=10)
     ffjord_d = FFJORDDistribution(FFJORD(nn, tspan, Tsit5(); p=res.u); regularize, monte_carlo)
 
     @test !isnothing(pdf(ffjord_d, train_data))
@@ -211,7 +211,7 @@ end
     end
 
     adtype = Optimization.AutoZygote()
-    res = DiffEqFlux.sciml_train(loss, ffjord_mdl.p, ADAM(0.1), adtype; callback= callback, maxiters=100)
+    res = DiffEqFlux.sciml_train(loss, ffjord_mdl.p, ADAM(1f-1), adtype; callback= callback, maxiters=100)
 
     actual_pdf = pdf.(data_dist, test_data)
     learned_pdf = exp.(ffjord_mdl(test_data, res.u; regularize, monte_carlo)[1])
@@ -239,7 +239,7 @@ end
     end
 
     adtype = Optimization.AutoZygote()
-    res = DiffEqFlux.sciml_train(loss, 0.01f0 * ffjord_mdl.p, ADAM(0.1), adtype; callback = callback, maxiters=100)
+    res = DiffEqFlux.sciml_train(loss, 0.01f0 * ffjord_mdl.p, ADAM(1f-1), adtype; callback = callback, maxiters=100)
 
     actual_pdf = pdf.(data_dist, test_data)
     learned_pdf = exp.(ffjord_mdl(test_data, res.u; regularize, monte_carlo)[1])
@@ -268,7 +268,7 @@ end
     end
 
     adtype = Optimization.AutoZygote()
-    res = DiffEqFlux.sciml_train(loss, 0.01f0 * ffjord_mdl.p, ADAM(0.1), adtype; callback = callback, maxiters=300)
+    res = DiffEqFlux.sciml_train(loss, 0.01f0 * ffjord_mdl.p, ADAM(1f-1), adtype; callback = callback, maxiters=300)
 
     actual_pdf = pdf(data_dist, test_data)
     learned_pdf = exp.(ffjord_mdl(test_data, res.u; regularize, monte_carlo)[1])
@@ -297,7 +297,7 @@ end
     end
 
     adtype = Optimization.AutoZygote()
-    res = DiffEqFlux.sciml_train(loss, 0.01f0 * ffjord_mdl.p, ADAM(0.1), adtype; callback = callback, maxiters=300)
+    res = DiffEqFlux.sciml_train(loss, 0.01f0 * ffjord_mdl.p, ADAM(1f-1), adtype; callback = callback, maxiters=300)
 
     actual_pdf = pdf(data_dist, test_data)
     learned_pdf = exp.(ffjord_mdl(test_data, res.u; regularize, monte_carlo)[1])

--- a/test/fast_neural_ode.jl
+++ b/test/fast_neural_ode.jl
@@ -5,7 +5,7 @@ datasize = 30
 tspan = (0.0f0,1.5f0)
 
 function trueODEfunc(du,u,p,t)
-    true_A = [-0.1 2.0; -2.0 -0.1]
+    true_A = Float32[-0.1 2.0; -2.0 -0.1]
     du .= ((u.^3)'true_A)'
 end
 t = range(tspan[1],tspan[2],length=datasize)
@@ -23,21 +23,6 @@ end
 
 function fast_loss_n_ode(p)
     pred = fast_predict_n_ode(p)
-    loss = sum(abs2,ode_data .- pred)
-    loss,pred
-end
-
-staticdudt2 = FastChain((x,p) -> x.^3,
-                        StaticDense(2,50,tanh),
-                        StaticDense(50,2))
-static_n_ode = NeuralODE(staticdudt2,tspan,Tsit5(),saveat=t)
-
-function static_predict_n_ode(p)
-  static_n_ode(u0,p)
-end
-
-function static_loss_n_ode(p)
-    pred = static_predict_n_ode(p)
     loss = sum(abs2,ode_data .- pred)
     loss,pred
 end
@@ -60,12 +45,5 @@ end
 p = initial_params(fastdudt2)
 _p,re = Flux.destructure(dudt2)
 @test fastdudt2(ones(2),_p) ≈ dudt2(ones(2))
-@test staticdudt2(ones(2),_p) ≈ dudt2(ones(2))
 @test fast_loss_n_ode(p)[1] ≈ loss_n_ode(p)[1]
-@test static_loss_n_ode(p)[1] ≈ loss_n_ode(p)[1]
 @test Zygote.gradient((p)->fast_loss_n_ode(p)[1], p)[1] ≈ Zygote.gradient((p)->loss_n_ode(p)[1], p)[1] rtol=4e-3
-@test Zygote.gradient((p)->static_loss_n_ode(p)[1], p)[1] ≈ Zygote.gradient((p)->loss_n_ode(p)[1], p)[1] rtol=4e-3
-
-# @btime Zygote.gradient((p)->static_loss_n_ode(p)[1], p)
-# @btime Zygote.gradient((p)->fast_loss_n_ode(p)[1], p)
-# @btime Zygote.gradient((p)->loss_n_ode(p)[1], p)

--- a/test/neural_de.jl
+++ b/test/neural_de.jl
@@ -253,12 +253,6 @@ gradsnc2 = Zygote.gradient(()->sum(sode(xs)),Flux.params(xs,sode))
 @test ! iszero(gradsnc2[sode.p])
 @test ! iszero(gradsnc2[sode.p][end])
 
-gradsc2 = Zygote.gradient(()->sum(sodec(xs)),Flux.params(xs,sodec))
-@test_broken gradsc2 isa Tuple
-@test ! iszero(gradsc2[xs])
-@test ! iszero(gradsc2[sodec.p])
-@test ! iszero(gradsc2[sodec.p][end])
-
 dudt22 = Flux.Chain(Flux.Dense(2,50,tanh),Flux.Dense(50,4),x->reshape(x,2,2))
 fastdudt22 = FastChain(FastDense(2,50,tanh),FastDense(50,4),(x,p)->reshape(x,2,2))
 NeuralSDE(dudt,dudt22,(0.0f0,.1f0),2,LambaEM(),saveat=0.01)(x)
@@ -288,11 +282,6 @@ gradsnc = Zygote.gradient(()->sum(sode(x)),Flux.params(x,sode))
 @test ! iszero(gradsnc[sode.p])
 @test ! iszero(gradsnc[sode.p][end])
 
-@test_broken gradsc = Zygote.gradient(()->sum(sodec(xs)),Flux.params(xs,sodec))
-@test_broken ! iszero(gradsc[xs])
-@test ! iszero(gradsc[sodec.p])
-@test ! iszero(gradsc[sodec.p][end])
-
 ddudt = Flux.Chain(Flux.Dense(6,50,tanh),Flux.Dense(50,2))
 NeuralCDDE(ddudt,(0.0f0,2.0f0),(p,t)->zero(x),(1f-1,2f-1),MethodOfSteps(Tsit5()),saveat=0.1)(x)
 dode = NeuralCDDE(ddudt,(0.0f0,2.0f0),(p,t)->zero(x),(1f-1,2f-1),MethodOfSteps(Tsit5()),saveat=0.0:0.1:2.0)
@@ -305,7 +294,6 @@ grads = Zygote.gradient(()->sum(dode(x)),Flux.params(x,dode))
 @test_broken ! iszero(grads[xs])
 @test ! iszero(grads[dode.p])
 
-
 fastddudt = FastChain(FastDense(6,50,tanh),FastDense(50,2))
 NeuralCDDE(fastddudt,(0.0f0,2.0f0),(p,t)->zero(x),(1f-1,2f-1),MethodOfSteps(Tsit5()),saveat=0.1)(x)
 dode = NeuralCDDE(fastddudt,(0.0f0,2.0f0),(p,t)->zero(x),(1f-1,2f-1),MethodOfSteps(Tsit5()),saveat=0.0:0.1:2.0)
@@ -317,17 +305,3 @@ gradsnc = Zygote.gradient(()->sum(dode(x)),Flux.params(x,dode))
 @test_broken gradsnc = Zygote.gradient(()->sum(dode(xs)),Flux.params(xs,dode)) isa Tuple
 @test_broken ! iszero(gradsnc[xs])
 @test ! iszero(gradsnc[dode.p])
-
-fastcddudt = FastChain(FastDense(6,50,tanh,numcols=size(xs)[2],precache=true),FastDense(50,2,numcols=size(xs)[2],precache=true))
-NeuralCDDE(fastcddudt,(0.0f0,2.0f0),(p,t)->zero(x),(1f-1,2f-1),MethodOfSteps(Tsit5()),saveat=0.1)(x)
-dodec = NeuralCDDE(fastcddudt,(0.0f0,2.0f0),(p,t)->zero(x),(1f-1,2f-1),MethodOfSteps(Tsit5()),saveat=0.0:0.1:2.0,p=pd)
-
-gradsc = Zygote.gradient(()->sum(dodec(x)),Flux.params(x,dodec))
-@test ! iszero(gradsc[x])
-@test ! iszero(gradsc[dodec.p])
-@test gradsnc[x] ≈ gradsc[x] rtol=1e-6
-@test gradsnc[dode.p] ≈ gradsc[dodec.p] rtol=1e-6
-
-@test_broken gradsc = Zygote.gradient(()->sum(dodec(xs)),Flux.params(xs,dodec)) isa Tuple
-@test_broken ! iszero(gradsc[xs])
-@test ! iszero(gradsc[dodec.p])

--- a/test/neural_de.jl
+++ b/test/neural_de.jl
@@ -7,7 +7,6 @@ tspan = (0.0f0,1.0f0)
 dudt = Flux.Chain(Flux.Dense(2,50,tanh),Flux.Dense(50,2))
 fastdudt = FastChain(FastDense(2,50,tanh),FastDense(50,2))
 fastcdudt = FastChain(FastDense(2,50,tanh,precache=true,numcols=size(xs)[2]),FastDense(50,2,precache=true,numcols=size(xs)[2]))
-staticdudt = FastChain(StaticDense(2,50,tanh),StaticDense(50,2))
 
 NeuralODE(dudt,tspan,Tsit5(),save_everystep=false,save_start=false)(x)
 NeuralODE(dudt,tspan,Tsit5(),saveat=0.1)(x)
@@ -139,19 +138,9 @@ grads = Zygote.gradient(()->sum(node(xs)),Flux.params(xs,node))
 goodgrad2 = grads[node.p]
 @test goodgradc ≈ goodgrad2 rtol=1e-6
 
-node = NeuralODE(staticdudt,tspan,Tsit5(),save_everystep=false,save_start=false,sensealg=BacksolveAdjoint(autojacvec=false),p=p)
-grads = Zygote.gradient(()->sum(node(x)),Flux.params(x,node))
-@test ! iszero(grads[x])
-@test ! iszero(grads[node.p])
-
 grads = Zygote.gradient(()->sum(node(xs)),Flux.params(xs,node))
 goodgrad2 = grads[node.p]
 @test goodgrad ≈ goodgrad2 rtol = 1e-6
-
-node = NeuralODE(staticdudt,tspan,Tsit5(),save_everystep=false,save_start=false,sensealg=BacksolveAdjoint(autojacvec=ZygoteVJP()),p=p)
-grads = Zygote.gradient(()->sum(node(x)),Flux.params(x,node))
-@test !iszero(grads[x])
-@test !iszero(grads[node.p])
 
 @test_throws ErrorException grads = Zygote.gradient(()->sum(node(xs)),Flux.params(xs,node))
 

--- a/test/neural_de.jl
+++ b/test/neural_de.jl
@@ -67,11 +67,6 @@ gradsnc2 = Zygote.gradient(()->sum(node(xs)),Flux.params(xs,node))
 @test ! iszero(gradsnc2[xs])
 @test ! iszero(gradsnc2[node.p])
 
-gradsc2 = Zygote.gradient(()->sum(nodec(xs)),Flux.params(xs,nodec))
-@test ! iszero(gradsc2[xs])
-@test ! iszero(gradsc2[nodec.p])
-@test gradsnc2[xs] ≈ gradsc2[xs] rtol=1e-6
-@test gradsnc2[node.p] ≈ gradsc2[nodec.p] rtol=1e-6
 #test with low tolerance ode solver
 node = NeuralODE(fastdudt, tspan, Tsit5(), abstol=1e-12, reltol=1e-12, save_everystep=false, save_start=false)
 pd = Flux.params(node)[1]

--- a/test/neural_de.jl
+++ b/test/neural_de.jl
@@ -6,7 +6,6 @@ xs = Float32.(hcat([0.; 0.], [1.; 0.], [2.; 0.]))
 tspan = (0.0f0,1.0f0)
 dudt = Flux.Chain(Flux.Dense(2,50,tanh),Flux.Dense(50,2))
 fastdudt = FastChain(FastDense(2,50,tanh),FastDense(50,2))
-fastcdudt = FastChain(FastDense(2,50,tanh,precache=true,numcols=size(xs)[2]),FastDense(50,2,precache=true,numcols=size(xs)[2]))
 
 NeuralODE(dudt,tspan,Tsit5(),save_everystep=false,save_start=false)(x)
 NeuralODE(dudt,tspan,Tsit5(),saveat=0.1)(x)
@@ -68,13 +67,6 @@ gradsnc2 = Zygote.gradient(()->sum(node(xs)),Flux.params(xs,node))
 @test ! iszero(gradsnc2[xs])
 @test ! iszero(gradsnc2[node.p])
 
-nodec = NeuralODE(fastcdudt,tspan,Tsit5(),save_everystep=false,save_start=false,p=pd)
-gradsc = Zygote.gradient(()->sum(nodec(x)),Flux.params(x,nodec)) #with cache
-@test ! iszero(gradsc[x])
-@test ! iszero(gradsc[nodec.p])
-@test gradsnc[x] ≈ gradsc[x] rtol=1e-6
-@test gradsnc[node.p] ≈ gradsc[nodec.p] rtol=1e-6
-
 gradsc2 = Zygote.gradient(()->sum(nodec(xs)),Flux.params(xs,nodec))
 @test ! iszero(gradsc2[xs])
 @test ! iszero(gradsc2[nodec.p])
@@ -87,11 +79,6 @@ gradsnc = Zygote.gradient(()->sum(node(x)),Flux.params(x,node))
 @test ! iszero(gradsnc[x])
 @test ! iszero(gradsnc[node.p])
 
-nodec = NeuralODE(fastcdudt, tspan, Tsit5(), abstol=1e-12, reltol=1e-12, save_everystep=false, save_start=false,p=pd)
-gradsc = Zygote.gradient(()->sum(nodec(x)),Flux.params(x,nodec))
-@test gradsnc[x] ≈ gradsc[x] rtol=1e-3
-@test gradsnc[node.p] ≈ gradsc[nodec.p] rtol=1e-3
-
 node = NeuralODE(fastdudt,tspan,Tsit5(),save_everystep=false,save_start=false,sensealg=TrackerAdjoint())
 grads = Zygote.gradient(()->sum(node(x)),Flux.params(x,node))
 @test ! iszero(grads[x])
@@ -103,11 +90,6 @@ grads = Zygote.gradient(()->sum(node(xs)),Flux.params(xs,node))
 
 goodgrad = grads[node.p]
 p = node.p
-
-node = NeuralODE(fastcdudt,tspan,Tsit5(),save_everystep=false,save_start=false,sensealg=TrackerAdjoint())
-grads = Zygote.gradient(()->sum(node(x)),Flux.params(x,node))
-@test ! iszero(grads[x])
-@test ! iszero(grads[node.p])
 
 grads = Zygote.gradient(()->sum(node(xs)),Flux.params(xs,node))
 @test ! iszero(grads[xs])
@@ -126,23 +108,6 @@ grads = Zygote.gradient(()->sum(node(xs)),Flux.params(xs,node))
 @test ! iszero(grads[node.p])
 goodgrad2 = grads[node.p]
 @test goodgrad ≈ goodgrad2 # Make sure adjoint overloads are correct
-
-node = NeuralODE(fastcdudt,tspan,Tsit5(),save_everystep=false,save_start=false, sensealg=BacksolveAdjoint(),p=pc)
-grads = Zygote.gradient(()->sum(node(x)),Flux.params(x,node))
-@test ! iszero(grads[x])
-@test ! iszero(grads[node.p])
-
-grads = Zygote.gradient(()->sum(node(xs)),Flux.params(xs,node))
-@test !iszero(grads[xs])
-@test ! iszero(grads[node.p])
-goodgrad2 = grads[node.p]
-@test goodgradc ≈ goodgrad2 rtol=1e-6
-
-grads = Zygote.gradient(()->sum(node(xs)),Flux.params(xs,node))
-goodgrad2 = grads[node.p]
-@test goodgrad ≈ goodgrad2 rtol = 1e-6
-
-@test_throws ErrorException grads = Zygote.gradient(()->sum(node(xs)),Flux.params(xs,node))
 
 @info "Test some adjoints"
 
@@ -184,15 +149,6 @@ goodgrad2 = grads[node.p]
     @test_broken ! iszero(grads[xs])
     @test_broken ! iszero(grads[node.p])
 
-    node = NeuralODE(fastcdudt,tspan,Tsit5(),save_everystep=false,save_start=false)
-    grads = Zygote.gradient(()->sum(node(x)),Flux.params(x,node))
-    @test ! iszero(grads[x])
-    @test ! iszero(grads[node.p])
-
-    @test_broken grads = Zygote.gradient(()->sum(node(xs)),Flux.params(xs,node)) isa Tuple
-    @test_broken ! iszero(grads[xs])
-    @test_broken ! iszero(grads[node.p])
-
     node = NeuralODE(fastdudt,tspan,Tsit5(),saveat=0.0:0.1:1.0)
     grads = Zygote.gradient(()->sum(node(x)),Flux.params(x,node))
     @test ! iszero(grads[x])
@@ -202,25 +158,7 @@ goodgrad2 = grads[node.p]
     @test_broken ! iszero(grads[xs])
     @test_broken ! iszero(grads[node.p])
 
-    node = NeuralODE(fastcdudt,tspan,Tsit5(),saveat=0.0:0.1:1.0)
-    grads = Zygote.gradient(()->sum(node(x)),Flux.params(x,node))
-    @test ! iszero(grads[x])
-    @test ! iszero(grads[node.p])
-
-    @test_broken grads = Zygote.gradient(()->sum(node(xs)),Flux.params(xs,node)) isa Tuple
-    @test_broken ! iszero(grads[xs])
-    @test_broken ! iszero(grads[node.p])
-
     node = NeuralODE(fastdudt,tspan,Tsit5(),saveat=0.1)
-    grads = Zygote.gradient(()->sum(node(x)),Flux.params(x,node))
-    @test ! iszero(grads[x])
-    @test ! iszero(grads[node.p])
-
-    @test_broken grads = Zygote.gradient(()->sum(node(xs)),Flux.params(xs,node)) isa Tuple
-    @test_broken ! iszero(grads[xs])
-    @test_broken ! iszero(grads[node.p])
-
-    node = NeuralODE(fastcdudt,tspan,Tsit5(),saveat=0.1)
     grads = Zygote.gradient(()->sum(node(x)),Flux.params(x,node))
     @test ! iszero(grads[x])
     @test ! iszero(grads[node.p])
@@ -270,25 +208,7 @@ end
     @test_broken ! iszero(grads[xs])
     @test_broken ! iszero(grads[node.p])
 
-    node = NeuralODE(fastcdudt,tspan,Tsit5(),save_everystep=false,save_start=false,sensealg=TrackerAdjoint())
-    grads = Zygote.gradient(()->sum(node(x)),Flux.params(x,node))
-    @test ! iszero(grads[x])
-    @test ! iszero(grads[node.p])
-
-    @test_broken grads = Zygote.gradient(()->sum(node(xs)),Flux.params(xs,node)) isa Tuple
-    @test_broken ! iszero(grads[xs])
-    @test_broken ! iszero(grads[node.p])
-
     node = NeuralODE(fastdudt,tspan,Tsit5(),saveat=0.0:0.1:1.0,sensealg=TrackerAdjoint())
-    grads = Zygote.gradient(()->sum(node(x)),Flux.params(x,node))
-    @test ! iszero(grads[x])
-    @test ! iszero(grads[node.p])
-
-    @test_broken grads = Zygote.gradient(()->sum(node(xs)),Flux.params(xs,node)) isa Tuple
-    @test_broken ! iszero(grads[xs])
-    @test_broken ! iszero(grads[node.p])
-
-    node = NeuralODE(fastcdudt,tspan,Tsit5(),saveat=0.0:0.1:1.0,sensealg=TrackerAdjoint())
     grads = Zygote.gradient(()->sum(node(x)),Flux.params(x,node))
     @test ! iszero(grads[x])
     @test ! iszero(grads[node.p])
@@ -305,22 +225,12 @@ end
     @test_broken grads = Zygote.gradient(()->sum(node(xs)),Flux.params(xs,node)) isa Tuple
     @test_broken ! iszero(grads[xs])
     @test_broken ! iszero(grads[node.p])
-
-    node = NeuralODE(fastcdudt,tspan,Tsit5(),saveat=0.1,sensealg=TrackerAdjoint())
-    grads = Zygote.gradient(()->sum(node(x)),Flux.params(x,node))
-    @test ! iszero(grads[x])
-    @test ! iszero(grads[node.p])
-
-    @test_broken grads = Zygote.gradient(()->sum(node(xs)),Flux.params(xs,node)) isa Tuple
-    @test_broken ! iszero(grads[xs])
-    @test_broken ! iszero(grads[node.p])
 end
 
 @info "Test non-ODEs"
 
 dudt2 = Flux.Chain(Flux.Dense(2,50,tanh),Flux.Dense(50,2))
 fastdudt2 = FastChain(FastDense(2,50,tanh),FastDense(50,2))
-fastcdudt2 = FastChain(FastDense(2,50,tanh,numcols=size(xs)[2],precache=true),FastDense(50,2,numcols=size(xs)[2],precache=true))
 NeuralDSDE(dudt,dudt2,(0.0f0,.1f0),SOSRI(),saveat=0.1)(x)
 sode = NeuralDSDE(dudt,dudt2,(0.0f0,.1f0),SOSRI(),saveat=0.0:0.01:0.1)
 
@@ -348,15 +258,6 @@ gradsnc2 = Zygote.gradient(()->sum(sode(xs)),Flux.params(xs,sode))
 @test ! iszero(gradsnc2[sode.p])
 @test ! iszero(gradsnc2[sode.p][end])
 
-sodec = NeuralDSDE(fastcdudt,fastcdudt2,(0.0f0,.1f0),SOSRI(),saveat=0.0:0.01:0.1,p=pd)
-Random.seed!(1234)
-gradsc = Zygote.gradient(()->sum(sodec(x)),Flux.params(x,sodec))
-@test ! iszero(gradsc[x])
-@test ! iszero(gradsc[sodec.p])
-@test ! iszero(gradsc[sodec.p][end])
-@test gradsnc[x] ≈ gradsc[x] rtol=1e-6
-@test gradsnc[sode.p] ≈ gradsc[sodec.p] rtol=1e-6
-
 gradsc2 = Zygote.gradient(()->sum(sodec(xs)),Flux.params(xs,sodec))
 @test_broken gradsc2 isa Tuple
 @test ! iszero(gradsc2[xs])
@@ -365,7 +266,6 @@ gradsc2 = Zygote.gradient(()->sum(sodec(xs)),Flux.params(xs,sodec))
 
 dudt22 = Flux.Chain(Flux.Dense(2,50,tanh),Flux.Dense(50,4),x->reshape(x,2,2))
 fastdudt22 = FastChain(FastDense(2,50,tanh),FastDense(50,4),(x,p)->reshape(x,2,2))
-fastcdudt22 = FastChain(FastDense(2,50,tanh,numcols=size(xs)[2],precache=true),FastDense(50,4,numcols=size(xs)[2],precache=true),(x,p)->reshape(x,2,2))
 NeuralSDE(dudt,dudt22,(0.0f0,.1f0),2,LambaEM(),saveat=0.01)(x)
 
 sode = NeuralSDE(dudt,dudt22,(0.0f0,0.1f0),2,LambaEM(),saveat=0.0:0.01:0.1)
@@ -392,15 +292,6 @@ gradsnc = Zygote.gradient(()->sum(sode(x)),Flux.params(x,sode))
 @test_broken ! iszero(gradsnc[xs])
 @test ! iszero(gradsnc[sode.p])
 @test ! iszero(gradsnc[sode.p][end])
-
-sodec = NeuralSDE(fastcdudt,fastcdudt22,(0.0f0,0.1f0),2,LambaEM(),saveat=0.0:0.01:0.1,p=pd)
-Random.seed!(1234)
-gradsc = Zygote.gradient(()->sum(sodec(x)),Flux.params(x,sodec))
-@test ! iszero(gradsc[x])
-@test ! iszero(gradsc[sodec.p])
-@test ! iszero(gradsc[sodec.p][end])
-@test gradsnc[x] ≈ gradsc[x] rtol=1e-6
-@test gradsnc[sode.p] ≈ gradsc[sodec.p] rtol=1e-6
 
 @test_broken gradsc = Zygote.gradient(()->sum(sodec(xs)),Flux.params(xs,sodec))
 @test_broken ! iszero(gradsc[xs])

--- a/test/newton_neural_ode.jl
+++ b/test/newton_neural_ode.jl
@@ -4,11 +4,11 @@ using DiffEqFlux, Optimization, OptimizationOptimJL, OrdinaryDiffEq, Random, Tes
 Random.seed!(100)
 
 n = 1 # number of ODEs
-tspan = (0.0, 1.0)
+tspan = (0f0, 1f0)
 
 d = 5 # number of data pairs
-x = rand(n, 5)
-y = rand(n, 5)
+x = rand(Float32, n, 5)
+y = rand(Float32, n, 5)
 
 cb = function (p,l)
   @show l
@@ -19,7 +19,7 @@ NN = Flux.Chain(Flux.Dense(n, 5n, tanh),
                 Flux.Dense(5n, n))
 
 @info "ROCK4"
-nODE = NeuralODE(NN, tspan, ROCK4(), reltol=1e-4, saveat=[tspan[end]])
+nODE = NeuralODE(NN, tspan, ROCK4(), reltol=1f-4, saveat=[tspan[end]])
 
 loss_function(θ) = Flux.Losses.mse(y, nODE(x, θ)[end])
 l1 = loss_function(nODE.p)
@@ -33,7 +33,7 @@ NN = FastChain(FastDense(n, 5n, tanh),
                FastDense(5n, n))
 
 @info "ROCK2"
-nODE = NeuralODE(NN, tspan, ROCK2(), reltol=1e-4, saveat=[tspan[end]])
+nODE = NeuralODE(NN, tspan, ROCK2(), reltol=1f-4, saveat=[tspan[end]])
 
 loss_function(θ) = Flux.Losses.mse(y, nODE(x, θ)[end])
 l1 = loss_function(nODE.p)


### PR DESCRIPTION
We already deprecated it, and it throws some things, and it wasn't really documented in the first place, so the best thing to do is just to drop it from the tests.