### PR TITLE
docs: remove ude and mention neural ode

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 DiffEq(For)Lux.jl (aka DiffEqFlux.jl) fuses the world of differential equations with machine learning
 by helping users put diffeq solvers into neural networks. This package utilizes
 [DifferentialEquations.jl](https://docs.sciml.ai/DiffEqDocs/stable/), and [Lux.jl](https://lux.csail.mit.edu/)  as its building blocks to support research in
-[Scientific Machine Learning](https://www.stochasticlifestyle.com/the-essential-tools-of-scientific-machine-learning-scientific-ml/), specifically neural differential equations and universal differential equations, to add physical information into traditional machine learning.
+[Scientific Machine Learning](https://www.stochasticlifestyle.com/the-essential-tools-of-scientific-machine-learning-scientific-ml/), specifically neural differential equations to add physical information into traditional machine learning.
 
 > [!NOTE]
 > We maintain backwards compatibility with [Flux.jl](https://docs.sciml.ai/Flux/stable/) via [Lux.transform](https://lux.csail.mit.edu/stable/api/Lux/flux_to_lux#Lux.transform)
@@ -27,25 +27,20 @@ the documentation, which contains the unreleased features.
 
 ## Problem Domain
 
-DiffEqFlux.jl is not just for neural ordinary differential equations.
-DiffEqFlux.jl is for universal differential equations, where these can include
-delays, physical constraints, stochasticity, events, and all other kinds of
-interesting behavior that shows up in scientific simulations. Neural networks can
-be all or part of the model. They can be around the differential equation,
-in the cost function, or inside of the differential equation. Neural networks
-representing unknown portions of the model or functions can go anywhere you
-have uncertainty in the form of the scientific simulator. For an overview of the
-topic with applications, consult the paper [Universal Differential Equations for
-Scientific Machine Learning](https://arxiv.org/abs/2001.04385).
+DiffEqFlux.jl is for neural ordinary differential equations.
+DiffEqFlux.jl provides architectures which match the interfaces of machine learning libraries such as Flux.jl and Lux.jl to make it easy to build continuous-time machine learning layers into larger machine learning applications.
 
-As such, it is the first package to support and demonstrate:
+The following layer functions exist:
 
-  - Stiff and non-stiff universal ordinary differential equations (universal ODEs)
-  - Universal stochastic differential equations (universal SDEs)
-  - Universal delay differential equations (universal DDEs)
-  - Universal partial differential equations (universal PDEs)
-  - Universal jump stochastic differential equations (universal jump diffusions)
-  - Hybrid universal differential equations (universal DEs with event handling)
+  - Neural Ordinary Differential Equations (Neural ODEs)
+  - Collocation-Based Neural ODEs (Neural ODEs without a solver, by far the fastest way!)
+  - Multiple Shooting Neural Ordinary Differential Equations
+  - Neural Stochastic Differential Equations (Neural SDEs)
+  - Neural Differential-Algebraic Equations (Neural DAEs)
+  - Neural Delay Differential Equations (Neural DDEs)
+  - Augmented Neural ODEs
+  - Hamiltonian Neural Networks (with specialized second order and symplectic integrators)
+  - Continuous Normalizing Flows (CNF) and FFJORD
 
 with high order, adaptive, implicit, GPU-accelerated, Newton-Krylov, etc.
 methods. For examples, please refer to

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ the documentation, which contains the unreleased features.
 
 ## Problem Domain
 
-DiffEqFlux.jl is for neural ordinary differential equations.
+DiffEqFlux.jl is for implicit layer machine learning.
 DiffEqFlux.jl provides architectures which match the interfaces of machine learning libraries such as Flux.jl and Lux.jl to make it easy to build continuous-time machine learning layers into larger machine learning applications.
 
 The following layer functions exist:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,15 +11,15 @@ and helper functions to make training such deep implicit layer models fast and e
     learning. For details on automatic differentiation of equation solvers
     and adjoint techniques, and using these methods for doing things like
     calibrating models to data, nonlinear optimal control, and PDE-constrained
-    optimization, see [SciMLSensitivity.jl](https://docs.sciml.ai/SciMLSensitivity/stable/)
+    optimization, see [SciMLSensitivity.jl](https://docs.sciml.ai/SciMLSensitivity/stable/).
 
 ## Pre-Built Architectures
 
 The approach of this package is the easy and efficient training of
-[Universal Differential Equations](https://arxiv.org/abs/2001.04385).
+[Neural Ordinary Differential Equations](https://arxiv.org/abs/1806.07366) and its variants.
 DiffEqFlux.jl provides architectures which match the interfaces of
 machine learning libraries such as [Flux.jl](https://docs.sciml.ai/Flux/stable/)
-and [Lux.jl](https://lux.csail.mit.edu/v0.5.5/api/)
+and [Lux.jl](https://lux.csail.mit.edu/stable/api/)
 to make it easy to build continuous-time machine learning layers
 into larger machine learning applications.
 


### PR DESCRIPTION
As DiffEqFlux is separated from SciMLSensitivity stuff, DiffEqFlux does not house anything related to UDEs.

I also noticed the links to the papers in https://docs.sciml.ai/DiffEqFlux/dev/#Pre-Built-Architectures to be not what I was expecting:
1. Neural SDEs point to Zygote's paper - https://arxiv.org/abs/1907.07587
2. Neural DAEs point to UDE paper - https://arxiv.org/abs/2001.04385
3. Neural DDEs also point to UDE paper - https://arxiv.org/abs/2001.04385
4. CNFs point to Neural ODE paper - https://arxiv.org/abs/1806.07366

I am not sure if that's intentional.

Also, the citation section consists of UDE paper, is there a DiffEqFlux paper to replace it?

Also, we don't have tutorials to NeuralDAEs, NeuralDDEs by looking at the list of current functionality and current tutorials.