### PR TITLE
Remove recompile_invalidations

### DIFF
--- a/src/DiffEqFlux.jl
+++ b/src/DiffEqFlux.jl
@@ -1,34 +1,30 @@
 module DiffEqFlux
 
-using PrecompileTools: @recompile_invalidations
-
-@recompile_invalidations begin
-    using ADTypes: ADTypes, AutoForwardDiff, AutoZygote
-    using ChainRulesCore: ChainRulesCore
-    using ConcreteStructs: @concrete
-    using Distributions: Distributions, ContinuousMultivariateDistribution, Distribution,
-                         logpdf
-    using DistributionsAD: DistributionsAD
-    using ForwardDiff: ForwardDiff
-    using Functors: Functors, fmap
-    using LinearAlgebra: LinearAlgebra, Diagonal, det, tr, mul!
-    using Lux: Lux, Chain, Dense, StatefulLuxLayer, FromFluxAdaptor, ⊠
-    using LuxCore: LuxCore, AbstractExplicitLayer, AbstractExplicitContainerLayer
-    using Random: Random, AbstractRNG, randn!
-    using Reexport: @reexport
-    using SciMLBase: SciMLBase, DAEProblem, DDEFunction, DDEProblem, EnsembleProblem,
-                     ODEFunction, ODEProblem, ODESolution, SDEFunction, SDEProblem, remake,
-                     solve
-    using SciMLSensitivity: SciMLSensitivity, AdjointLSS, BacksolveAdjoint, EnzymeVJP,
-                            ForwardDiffOverAdjoint, ForwardDiffSensitivity, ForwardLSS,
-                            ForwardSensitivity, GaussAdjoint, InterpolatingAdjoint, NILSAS,
-                            NILSS, QuadratureAdjoint, ReverseDiffAdjoint, ReverseDiffVJP,
-                            SteadyStateAdjoint, TrackerAdjoint, TrackerVJP, ZygoteAdjoint,
-                            ZygoteVJP
-    using Setfield: @set
-    using Tracker: Tracker
-    using Zygote: Zygote
-end
+using ADTypes: ADTypes, AutoForwardDiff, AutoZygote
+using ChainRulesCore: ChainRulesCore
+using ConcreteStructs: @concrete
+using Distributions: Distributions, ContinuousMultivariateDistribution, Distribution,
+                     logpdf
+using DistributionsAD: DistributionsAD
+using ForwardDiff: ForwardDiff
+using Functors: Functors, fmap
+using LinearAlgebra: LinearAlgebra, Diagonal, det, tr, mul!
+using Lux: Lux, Chain, Dense, StatefulLuxLayer, FromFluxAdaptor, ⊠
+using LuxCore: LuxCore, AbstractExplicitLayer, AbstractExplicitContainerLayer
+using Random: Random, AbstractRNG, randn!
+using Reexport: @reexport
+using SciMLBase: SciMLBase, DAEProblem, DDEFunction, DDEProblem, EnsembleProblem,
+                 ODEFunction, ODEProblem, ODESolution, SDEFunction, SDEProblem, remake,
+                 solve
+using SciMLSensitivity: SciMLSensitivity, AdjointLSS, BacksolveAdjoint, EnzymeVJP,
+                        ForwardDiffOverAdjoint, ForwardDiffSensitivity, ForwardLSS,
+                        ForwardSensitivity, GaussAdjoint, InterpolatingAdjoint, NILSAS,
+                        NILSS, QuadratureAdjoint, ReverseDiffAdjoint, ReverseDiffVJP,
+                        SteadyStateAdjoint, TrackerAdjoint, TrackerVJP, ZygoteAdjoint,
+                        ZygoteVJP
+using Setfield: @set
+using Tracker: Tracker
+using Zygote: Zygote
 
 const CRC = ChainRulesCore
 

--- a/src/DiffEqFlux.jl
+++ b/src/DiffEqFlux.jl
@@ -3,8 +3,7 @@ module DiffEqFlux
 using ADTypes: ADTypes, AutoForwardDiff, AutoZygote
 using ChainRulesCore: ChainRulesCore
 using ConcreteStructs: @concrete
-using Distributions: Distributions, ContinuousMultivariateDistribution, Distribution,
-                     logpdf
+using Distributions: Distributions, ContinuousMultivariateDistribution, Distribution, logpdf
 using DistributionsAD: DistributionsAD
 using ForwardDiff: ForwardDiff
 using Functors: Functors, fmap


### PR DESCRIPTION
`@recompile_invalidations` should only be used in very specific scenarios, and this is not one of those scenarios. Also, there are big changes being done with https://github.com/SciML/CommonWorldInvalidations.jl. With that, we only need to `@recompile_invalidations` on a few entry points. In particular, Static.jl, Symbolics.jl, and preferably ForwardDiff.jl and StaticArrays.jl would adopt it too. But this means that in order to handle all of this effectively, in SciML we only need to apply it on Static.jl, Symbolics.jl, and SciMLBase.jl and the whole ecosystem should be fine.

In any case, this library doesn't need it. It shouldn't make a tangible difference in compile times, while it increases precompile times by a lot.