### PR TITLE
docs: update performance wording

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -62,9 +62,9 @@ the precision of the arguments are correct, and anything that requires alternati
 `ForwardDiffSensitivity` dual numbers) are suspect.
 
 Lux.jl has none of these issues, is simpler to work with due to the parameters in its function calls being explicit rather than implicit global
-references, and achieves higher performance. It is built on the same foundations as Flux.jl, such as Zygote and NNLib, and thus it supports the
-same layers underneath and calls the same kernels. The better performance comes from not having the overhead of `restructure` required.
-Thus we highly recommend people use Lux instead and only use the Flux fallbacks for legacy code.
+references, and achieves higher performance. It is built on similar foundations as Flux.jl, such as Zygote and NNLib. The better performance
+comes from not having the overhead of `restructure` required and fusing common operations in LuxLib.jl. Thus we highly recommend people use
+Lux instead and only use the Flux fallbacks for legacy code.
 
 ## Citation
 


### PR DESCRIPTION
The previous wording is no longer true. Most common operations get routed through LuxLib.jl and the performance comes from using more fused kernels (and simd loops instead of broadcasting on CPU)