### PR TITLE
Included definition of v in this example

### DIFF
--- a/docs/src/examples/tensor_layer.md
+++ b/docs/src/examples/tensor_layer.md
@@ -9,6 +9,13 @@ Let's consider the anharmonic oscillator described by the ODE
 ẍ = - kx - αx³ - βẋ -γẋ³.
 ```
 
+We first transform this second order differential equation into a system of first order
+differential equations for use in `DiffEqFlux`: We let `ẋ = v` then 
+```math
+ẋ = v \\
+v̇ = - kx - αx³ - βv̇ -γv̇³.
+```
+
 To obtain the training data, we solve the equation of motion using one of the
 solvers in `DifferentialEquations`:
 


### PR DESCRIPTION
Previously v was left undefined in this example. I added the system of ODEs you can from this second order differential equation so that readers know that v is. Perhaps this is obvious from physics perspective but not necessarily from other practices.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
