### PR TITLE
[ci skip] Fix backpropagation spelling

### DIFF
--- a/src/neural_de.jl
+++ b/src/neural_de.jl
@@ -20,7 +20,7 @@ Arguments:
   - `tspan`: The timespan to be solved on.
   - `alg`: The algorithm used to solve the ODE. Defaults to `nothing`, i.e. the
     default algorithm from DifferentialEquations.jl.
-  - `sensealg`: The choice of differentiation algorithm used in the backpropogation.
+  - `sensealg`: The choice of differentiation algorithm used in the backpropagation.
     Defaults to an adjoint method. See
     the [Local Sensitivity Analysis](https://docs.sciml.ai/SciMLSensitivity/stable/)
     documentation for more details.
@@ -72,7 +72,7 @@ Arguments:
   - `tspan`: The timespan to be solved on.
   - `alg`: The algorithm used to solve the ODE. Defaults to `nothing`, i.e. the
     default algorithm from DifferentialEquations.jl.
-  - `sensealg`: The choice of differentiation algorithm used in the backpropogation.
+  - `sensealg`: The choice of differentiation algorithm used in the backpropagation.
   - `kwargs`: Additional arguments splatted to the ODE solver. See the
     [Common Solver Arguments](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/)
     documentation for more details.
@@ -121,7 +121,7 @@ Arguments:
   - `nbrown`: The number of Brownian processes.
   - `alg`: The algorithm used to solve the ODE. Defaults to `nothing`, i.e. the
     default algorithm from DifferentialEquations.jl.
-  - `sensealg`: The choice of differentiation algorithm used in the backpropogation.
+  - `sensealg`: The choice of differentiation algorithm used in the backpropagation.
   - `kwargs`: Additional arguments splatted to the ODE solver. See the
     [Common Solver Arguments](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/)
     documentation for more details.
@@ -175,7 +175,7 @@ Arguments:
   - `lags`: Defines the lagged values that should be utilized in the neural network.
   - `alg`: The algorithm used to solve the ODE. Defaults to `nothing`, i.e. the
     default algorithm from DifferentialEquations.jl.
-  - `sensealg`: The choice of differentiation algorithm used in the backpropogation.
+  - `sensealg`: The choice of differentiation algorithm used in the backpropagation.
     Defaults to using reverse-mode automatic differentiation via Tracker.jl
   - `kwargs`: Additional arguments splatted to the ODE solver. See the
     [Common Solver Arguments](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/)
@@ -226,7 +226,7 @@ Arguments:
   - `tspan`: The timespan to be solved on.
   - `alg`: The algorithm used to solve the ODE. Defaults to `nothing`, i.e. the
     default algorithm from DifferentialEquations.jl.
-  - `sensealg`: The choice of differentiation algorithm used in the backpropogation.
+  - `sensealg`: The choice of differentiation algorithm used in the backpropagation.
     Defaults to using reverse-mode automatic differentiation via Tracker.jl
   - `kwargs`: Additional arguments splatted to the ODE solver. See the
     [Common Solver Arguments](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/)
@@ -299,7 +299,7 @@ Arguments:
     compatible with singular mass matrices. Consult the
     [DAE solvers](https://docs.sciml.ai/DiffEqDocs/stable/solvers/dae_solve/) documentation
     for more details.
-  - `sensealg`: The choice of differentiation algorithm used in the backpropogation.
+  - `sensealg`: The choice of differentiation algorithm used in the backpropagation.
     Defaults to an adjoint method. See
     the [Local Sensitivity Analysis](https://docs.sciml.ai/SciMLSensitivity/stable/)
     documentation for more details.


### PR DESCRIPTION
## Summary

This PR fixes a spelling error: backpropogation → backpropagation.

## Changes Made

- Fixed the misspelling of backpropagation in comments/documentation
- Simple typo correction that doesn't affect functionality

## Notes

-  included to avoid unnecessary CI runs for spelling fixes
- This is a clear spelling error, not a technical term variation