### PR TITLE
Restore the network-construction surface on `using DiffEqFlux`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,7 @@ DataInterpolations = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
 DiffEqFluxDataInterpolationsExt = "DataInterpolations"
 
 [compat]
-ADTypes = "1.21"
+ADTypes = "1.22"
 Aqua = "0.8.16"
 BenchmarkTools = "1.5.0"
 Boltz = "1.7"

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -21,6 +21,7 @@ pages = [
         "Continuous Normalizing Flows Layer" => "layers/CNFLayer.md",
         "Neural Differential Equation Layers" => "layers/NeuralDELayers.md",
     ],
+    "Reexported API" => "reexports.md",
     "Utility Function APIs" => Any[
         "Smoothed Collocation" => "utilities/Collocation.md",
         "Multiple Shooting Functionality" => "utilities/MultipleShooting.md"

--- a/docs/src/reexports.md
+++ b/docs/src/reexports.md
@@ -1,0 +1,82 @@
+# Reexported API
+
+`using DiffEqFlux` brings a small, deliberate slice of its dependencies into scope on
+top of DiffEqFlux's own layers, so that the examples in this documentation can build a
+neural differential equation end to end without a second `using`. Every name below is
+**owned and documented by the upstream package** -- DiffEqFlux only re-exports it, and
+the upstream documentation is where to look for what each one does.
+
+Anything not on this page must be imported from its own package. In particular, the
+canonical way to work with DiffEqFlux is still
+
+```julia
+using DiffEqFlux, Lux
+```
+
+which gives the full Lux surface; the re-exports here only cover what the DiffEqFlux
+documentation itself uses.
+
+## Network construction ([Lux.jl](https://lux.csail.mit.edu/stable/))
+
+The `Lux` module itself is re-exported (so `Lux.setup`, `Lux.Chain`, ... work), along
+with the layers used by this documentation:
+
+  - Containers and basic layers: `Chain`, `Dense`, `WrappedFunction`
+  - Convolutional and pooling layers: `Conv`, `MaxPool`, `MeanPool`, `FlattenLayer`,
+    `SamePad`
+  - Normalization: `GroupNorm`
+  - Stateful wrapper: `StatefulLuxLayer`
+  - Flux interop: `FromFluxAdaptor`
+  - Precision helpers: `f32`, `f64`
+  - The `Training` module
+
+The rest of Lux -- its full layer zoo, loss functions, activation functions (owned by
+NNlib), weight initializers (owned by WeightInitializers) and device helpers (owned by
+MLDataDevices) -- is **not** re-exported. Use `using Lux` for those.
+
+## Layer contract ([LuxCore.jl](https://lux.csail.mit.edu/stable/api/Building_Blocks/LuxCore))
+
+The abstract types you subtype to write your own layer, and the functions that layer
+must support:
+
+  - `AbstractLuxLayer`, `AbstractLuxContainerLayer`, `AbstractLuxWrapperLayer`
+  - `setup`, `apply`, `initialparameters`, `initialstates`, `parameterlength`,
+    `statelength`, `testmode`, `trainmode`
+  - the `LuxCore` module itself
+
+## Differentiation backends ([ADTypes.jl](https://sciml.github.io/ADTypes.jl/stable/))
+
+The backend selectors passed to `ad =` on layers such as [`FFJORD`](@ref) and to
+`Optimization.OptimizationFunction`:
+
+`AutoChainRules`, `AutoDiffractor`, `AutoEnzyme`, `AutoFastDifferentiation`,
+`AutoFiniteDiff`, `AutoFiniteDifferences`, `AutoForwardDiff`, `AutoGTPSA`,
+`AutoHyperHessians`, `AutoModelingToolkit`, `AutoMooncake`, `AutoMooncakeForward`,
+`AutoPolyesterForwardDiff`, `AutoReactant`, `AutoReverseDiff`, `AutoSparse`,
+`AutoSymbolics`, `AutoTaylorDiff`, `AutoTracker`, `AutoZygote`, plus `AbstractADType`
+and the `ADTypes` module.
+
+ADTypes' sparsity-detection and coloring interfaces are not re-exported; use
+`using ADTypes` for those.
+
+## Model zoo ([Boltz.jl](https://luxdl.github.io/Boltz.jl/stable/))
+
+  - `Layers` -- e.g. `Layers.HamiltonianNN`, `Layers.TensorProductLayer`
+  - `Basis` -- e.g. `Basis.Legendre`
+  - the `Boltz` module itself
+
+Boltz's `Vision` and `PIML` submodules are not re-exported; use `using Boltz` for
+those.
+
+## Sensitivity analysis ([SciMLSensitivity.jl](https://docs.sciml.ai/SciMLSensitivity/stable/))
+
+The adjoint and vector-Jacobian-product choices passed through to the solver:
+
+  - Adjoints: `BacksolveAdjoint`, `QuadratureAdjoint`, `GaussAdjoint`,
+    `InterpolatingAdjoint`, `TrackerAdjoint`, `ZygoteAdjoint`, `ReverseDiffAdjoint`,
+    `SteadyStateAdjoint`, `ForwardDiffOverAdjoint`
+  - Forward sensitivity: `ForwardSensitivity`, `ForwardDiffSensitivity`
+  - Shadowing methods: `ForwardLSS`, `AdjointLSS`, `NILSS`, `NILSAS`
+  - VJP choices: `TrackerVJP`, `ZygoteVJP`, `EnzymeVJP`, `ReverseDiffVJP`
+
+Anything else from SciMLSensitivity must be imported from SciMLSensitivity directly.

--- a/src/DiffEqFlux.jl
+++ b/src/DiffEqFlux.jl
@@ -1,7 +1,7 @@
 module DiffEqFlux
 
 using ADTypes: ADTypes, AutoForwardDiff, AutoZygote
-using Boltz: Boltz, Layers
+using Boltz: Boltz, Basis, Layers
 using ChainRulesCore: ChainRulesCore
 using ConcreteStructs: @concrete
 using Distributions: Distributions, ContinuousMultivariateDistribution, Distribution, logpdf
@@ -24,7 +24,24 @@ using Static: True, False
 
 const CRC = ChainRulesCore
 
-using ADTypes, Lux, Boltz
+# The neural-network construction surface that DiffEqFlux reexports (see the `export`
+# blocks at the bottom of this file), so that `using DiffEqFlux` on its own is enough to
+# build the network a `NeuralODE`/`NeuralDSDE`/`FFJORD` wraps and to pick an AD backend
+# for it. Every name stays owned and documented upstream:
+#
+#   * layers and the Flux adaptor from Lux,
+#   * the layer contract (`setup`, `apply`, ...) from LuxCore,
+#   * the `Auto*` differentiation selectors from ADTypes,
+#   * the `Layers`/`Basis` model zoo modules from Boltz.
+using Lux: Conv, FlattenLayer, GroupNorm, MaxPool, MeanPool, SamePad, Training,
+    WrappedFunction, f32, f64
+using LuxCore: apply, initialparameters, initialstates, parameterlength, setup,
+    statelength, testmode, trainmode
+using ADTypes: AbstractADType, AutoChainRules, AutoDiffractor, AutoEnzyme,
+    AutoFastDifferentiation, AutoFiniteDiff, AutoFiniteDifferences, AutoGTPSA,
+    AutoHyperHessians, AutoModelingToolkit, AutoMooncake, AutoMooncakeForward,
+    AutoPolyesterForwardDiff, AutoReactant, AutoReverseDiff, AutoSparse, AutoSymbolics,
+    AutoTaylorDiff, AutoTracker
 
 fixed_state_type(_) = true
 fixed_state_type(::Layers.HamiltonianNN{True}) = true
@@ -54,6 +71,20 @@ export BacksolveAdjoint, QuadratureAdjoint, GaussAdjoint, InterpolatingAdjoint,
     ForwardDiffSensitivity, ForwardDiffOverAdjoint, SteadyStateAdjoint, ForwardLSS,
     AdjointLSS, NILSS, NILSAS
 export TrackerVJP, ZygoteVJP, EnzymeVJP, ReverseDiffVJP
+
+# Reexported neural-network construction surface; approved via `reexports_allow` in
+# test/QA/qa_tests.jl and documented in docs/src/reexports.md.
+export Lux, Chain, Dense, Conv, MaxPool, MeanPool, FlattenLayer, GroupNorm, SamePad,
+    WrappedFunction, StatefulLuxLayer, FromFluxAdaptor, Training, f32, f64
+export LuxCore, AbstractLuxLayer, AbstractLuxContainerLayer, AbstractLuxWrapperLayer,
+    setup, apply, initialparameters, initialstates, parameterlength, statelength,
+    testmode, trainmode
+export ADTypes, AbstractADType, AutoChainRules, AutoDiffractor, AutoEnzyme,
+    AutoFastDifferentiation, AutoFiniteDiff, AutoFiniteDifferences, AutoForwardDiff,
+    AutoGTPSA, AutoHyperHessians, AutoModelingToolkit, AutoMooncake, AutoMooncakeForward,
+    AutoPolyesterForwardDiff, AutoReactant, AutoReverseDiff, AutoSparse, AutoSymbolics,
+    AutoTaylorDiff, AutoTracker, AutoZygote
+export Boltz, Basis, Layers
 
 # Precompilation workload - must be at the end
 include("precompilation.jl")

--- a/test/QA/qa_tests.jl
+++ b/test/QA/qa_tests.jl
@@ -1,16 +1,41 @@
-using SciMLTesting, DiffEqFlux
+using SciMLTesting, DiffEqFlux, Test
+
+# The dependency-owned names DiffEqFlux deliberately reexports, so that
+# `using DiffEqFlux` is enough to build a neural differential equation end to end:
+# the SciMLSensitivity adjoint/VJP choices, the Lux layers and LuxCore layer contract
+# used to build the network, the ADTypes `Auto*` selectors, and the Boltz `Layers`/
+# `Basis` model zoo modules. Each name is owned and documented upstream; kept in sync
+# with the `export` blocks in src/DiffEqFlux.jl and the list in docs/src/reexports.md.
+const REEXPORTS = (
+    # SciMLSensitivity: the solver-facing sensitivity facade.
+    :AdjointLSS, :BacksolveAdjoint, :EnzymeVJP, :ForwardDiffOverAdjoint,
+    :ForwardDiffSensitivity, :ForwardLSS, :ForwardSensitivity, :GaussAdjoint,
+    :InterpolatingAdjoint, :NILSAS, :NILSS, :QuadratureAdjoint,
+    :ReverseDiffAdjoint, :ReverseDiffVJP, :SteadyStateAdjoint, :TrackerAdjoint,
+    :TrackerVJP, :ZygoteAdjoint, :ZygoteVJP,
+    # Lux: network construction.
+    :Chain, :Conv, :Dense, :FlattenLayer, :FromFluxAdaptor, :GroupNorm, :Lux, :MaxPool,
+    :MeanPool, :SamePad, :StatefulLuxLayer, :Training, :WrappedFunction, :f32, :f64,
+    # LuxCore: the layer contract.
+    :AbstractLuxContainerLayer, :AbstractLuxLayer, :AbstractLuxWrapperLayer, :LuxCore,
+    :apply, :initialparameters, :initialstates, :parameterlength, :setup, :statelength,
+    :testmode, :trainmode,
+    # ADTypes: the differentiation backend selectors.
+    :ADTypes, :AbstractADType, :AutoChainRules, :AutoDiffractor, :AutoEnzyme,
+    :AutoFastDifferentiation, :AutoFiniteDiff, :AutoFiniteDifferences, :AutoForwardDiff,
+    :AutoGTPSA, :AutoHyperHessians, :AutoModelingToolkit, :AutoMooncake,
+    :AutoMooncakeForward, :AutoPolyesterForwardDiff, :AutoReactant, :AutoReverseDiff,
+    :AutoSparse, :AutoSymbolics, :AutoTaylorDiff, :AutoTracker, :AutoZygote,
+    # Boltz: the model zoo modules the examples build layers from.
+    :Basis, :Boltz, :Layers,
+)
 
 run_qa(
     DiffEqFlux;
-    # These explicitly exported SciMLSensitivity adjoint algorithms are part of
-    # DiffEqFlux's documented solver-facing facade.
-    reexports_allow = (
-        :AdjointLSS, :BacksolveAdjoint, :EnzymeVJP, :ForwardDiffOverAdjoint,
-        :ForwardDiffSensitivity, :ForwardLSS, :ForwardSensitivity, :GaussAdjoint,
-        :InterpolatingAdjoint, :NILSAS, :NILSS, :QuadratureAdjoint,
-        :ReverseDiffAdjoint, :ReverseDiffVJP, :SteadyStateAdjoint, :TrackerAdjoint,
-        :TrackerVJP, :ZygoteAdjoint, :ZygoteVJP,
-    ),
+    reexports_allow = REEXPORTS,
+    # `SamePad` is exported by Lux without a docstring (LuxDL/Lux.jl); drop the ignore
+    # once Lux documents it.
+    api_docs_kwargs = (; ignore = (:SamePad,)),
     # `ambiguities = false` in test_all + a separate non-recursive ambiguity check
     # historically; keep ambiguities on but non-recursive (recursive hits the deep
     # Lux/SciMLSensitivity stack and is not DiffEqFlux's responsibility).
@@ -29,3 +54,14 @@ run_qa(
         ),
     ),
 )
+
+@testset "Reexport surface" begin
+    # Every approved reexport must actually be reachable from `using DiffEqFlux`, so the
+    # allow-list cannot drift into approving names the package no longer provides.
+    # `isdefined(@__MODULE__, ...)` tests the property directly: this file's
+    # `using DiffEqFlux` is what has to bring the name into scope.
+    @testset "$name" for name in REEXPORTS
+        @test name in names(DiffEqFlux)
+        @test isdefined(@__MODULE__, name)
+    end
+end


### PR DESCRIPTION
## What broke

`4500140d` ("qa: remove blanket dependency reexports", #1051) deleted

```julia
@reexport using ADTypes, Lux, Boltz
```

`using DiffEqFlux` on its own no longer provides `Chain`, `Dense`,
`StatefulLuxLayer`, the `Lux` module binding (so `Lux.setup` fails), Boltz's
`Layers`/`Basis`, or the ADTypes `Auto*` selectors -- all of which this package's
own documentation uses bare.

## Evidence used to pick the restored names

I scanned every fenced code block under `docs/src` for names in
`names(Lux) ∪ names(ADTypes) ∪ names(Boltz)` that are **not** in
`names(DiffEqFlux)` and that the containing file's own `using` line does not
cover. That is exactly the set of documentation examples that stopped working:

| name | broken in |
|---|---|
| `Chain`, `Dense` | `index.md`, `examples/normalizing_flows.md`, `examples/neural_sde.md` |
| `StatefulLuxLayer` | `normalizing_flows.md`, `neural_sde.md`, `tensor_layer.md` |
| `Lux` (for `Lux.setup`) | `normalizing_flows.md`, `neural_sde.md`, `tensor_layer.md` |
| `Basis`, `Layers` | `tensor_layer.md` |
| `AutoZygote` | `normalizing_flows.md`, `neural_sde.md`, `tensor_layer.md` |
| `AutoForwardDiff` | `normalizing_flows.md` |
| `AutoFiniteDiff` | `physical_constraints.md` |

For example `docs/src/examples/normalizing_flows.md` is

```julia
using ComponentArrays, DiffEqFlux, OrdinaryDiffEq, Optimization, Distributions, Random,
      OptimizationOptimisers, OptimizationOptimJL

nn = Chain(Dense(1, 3, tanh), Dense(3, 1, tanh))
ffjord_mdl = FFJORD(nn, tspan, (1,), Tsit5(); ad = AutoZygote())
ps, st = Lux.setup(Xoshiro(0), ffjord_mdl)
model = StatefulLuxLayer{true}(ffjord_mdl, nothing, st)
```

which is five `UndefVarError`s on current master.

**Why CI did not notice:** the same commit converted **89 `@example` blocks to
plain `julia` blocks**, so the documentation examples no longer execute at all
(only three hidden `Pkg` blocks in `index.md` still do). That is worth a separate
look; this PR does not change it, because re-enabling them will surface unrelated
failures and long doc builds.

## What is restored

Following SciML/Sundials.jl#553 -- reexport what normal documented use needs, not
whole dependencies -- an explicit list replaces the blanket reexport:

  - **Lux** (network construction): `Lux`, `Chain`, `Dense`, `Conv`, `MaxPool`,
    `MeanPool`, `FlattenLayer`, `GroupNorm`, `SamePad`, `WrappedFunction`,
    `StatefulLuxLayer`, `FromFluxAdaptor`, `Training`, `f32`, `f64`
  - **LuxCore** (layer contract): `LuxCore`, `AbstractLuxLayer`,
    `AbstractLuxContainerLayer`, `AbstractLuxWrapperLayer`, `setup`, `apply`,
    `initialparameters`, `initialstates`, `parameterlength`, `statelength`,
    `testmode`, `trainmode`
  - **ADTypes** (differentiation selectors): `ADTypes`, `AbstractADType`, and the
    twenty `Auto*` backends
  - **Boltz** (model zoo): `Boltz`, `Layers`, `Basis`

Deliberately **not** restored, and stated as such on the docs page: Lux's
remaining layer zoo and loss functions, the NNlib activations, the
WeightInitializers initializers, the MLDataDevices device helpers, ADTypes'
sparsity-detection/coloring interfaces, and Boltz's `Vision`/`PIML`. `using
DiffEqFlux, Lux` remains the canonical pair for anything beyond the list.

`names(DiffEqFlux)` goes from 43 to 95 (the pre-`4500140d` reexport put ~330
names in scope).

## Documentation

New page `docs/src/reexports.md` ("Reexported API"), wired into `docs/pages.jl`.
It groups the names by **owning package** -- Lux / LuxCore / ADTypes / Boltz /
SciMLSensitivity -- links each group to that package's own documentation, makes
clear that `Chain`/`Dense` are Lux's and the `Auto*` selectors are ADTypes', and
closes each group with an explicit boundary line. The page, the `export` blocks in
`src/DiffEqFlux.jl` and the `REEXPORTS` tuple in `test/QA/qa_tests.jl` are the
same list in three places.

The previously-undeclared SciMLSensitivity reexports (adjoints and VJP choices)
are now documented on the same page too; they were already exported and already in
`reexports_allow`, so nothing about them changes in code.

## Why this is not breaking

Every restored name was exported by `using DiffEqFlux` before `4500140d`.
Restoring previously-exported names is additive. No version bump here; the release
pass handles versions.

## What was verified (run, not just inspected)

- `test/QA/qa_tests.jl` runs clean locally: **Quality Assurance 20/20 pass**
  (Aqua incl. ambiguities/piracy/persistent tasks, all six ExplicitImports checks
  -- including `all_explicit_imports_via_owners`, since every restored name is
  imported from the module that owns it -- the public API documentation checks,
  and `No unapproved public reexports`), plus a new **Reexport surface testset,
  142/142 pass**, asserting each approved name is in `names(DiffEqFlux)` and in
  scope from `using DiffEqFlux`.
- One `api_docs_kwargs` ignore was needed: `SamePad` is exported by Lux with no
  docstring upstream. It is annotated as such and should be dropped once Lux
  documents it.
- The broken documentation snippets above were re-run from a bare
  `using DiffEqFlux, OrdinaryDiffEq, Random, ComponentArrays`: the FFJORD block
  from `normalizing_flows.md`, the `Chain(Dense(2, 10, tanh), Dense(10, 1))` from
  `index.md`, the `Basis.Legendre` / `Layers.TensorProductLayer` block from
  `tensor_layer.md`, the three `Auto*` selectors, and the LuxCore
  `setup`/`parameterlength` contract. All succeed.
- Runic reports no formatting changes on the touched Julia files.
- The full test suite and the documentation build were **not** run locally (this
  machine is heavily loaded and the doc examples are training runs); CI covers
  them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
