### PR TITLE
Raise the ADTypes floor for restored reexports

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,7 @@ DataInterpolations = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
 DiffEqFluxDataInterpolationsExt = "DataInterpolations"
 
 [compat]
-ADTypes = "1.21"
+ADTypes = "1.22"
 Aqua = "0.8.16"
 BenchmarkTools = "1.5.0"
 Boltz = "1.7"


### PR DESCRIPTION
This stacked PR raises the ADTypes compatibility floor required by the parent reexport restoration. `AutoHyperHessians` first appears in registered ADTypes 1.22.0, so the explicit import added by the parent cannot precompile at its declared 1.21 floor.

Parent PR: https://github.com/SciML/DiffEqFlux.jl/pull/1054

Ignore this PR until reviewed by @ChrisRackauckas.

## Registered-tag floor audit

I cloned each owning package afresh, mapped every restored name across every registered non-yanked tag, chose the maximum introduction version, and checked that no later registered version drops a required name.

| Owner | Minimal continuous floor for this surface | Declared floor/result |
|---|---:|---|
| ADTypes | 1.22.0 (`AutoHyperHessians`) | raised from 1.21 to 1.22 |
| Lux | 0.5.62 (`Training`) | existing 1.29 is sufficient |
| LuxCore | 1.4.2 | existing 1.5.2 is sufficient |
| Boltz | 1.0.0 | existing 1.7 is sufficient |

ADTypes 1.21 produces `UndefVarError: AutoHyperHessians not defined in DiffEqFlux`; ADTypes 1.22 loads and verifies the restored binding. The ADTypes scan covered all 52 registered versions and found no later gaps.

## Local verification

- `GROUP=QA ~/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` -> `QA | 162 / 162`, `Testing DiffEqFlux tests passed`.
- `GROUP=PublicInterface ~/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` -> `Public interfaces | 45 / 45`, `Testing DiffEqFlux tests passed`.
- `~/.juliaup/bin/julia +release --project=docs docs/make.jl` -> exit 0 after doctests, cross-references, document checks, and HTML rendering.
- `curl -L` -> HTTP 200 for every owning-package link added by the parent docs page (Lux, LuxCore, ADTypes, Boltz, and SciMLSensitivity).
- `~/.juliaup/bin/julia +release -m Runic --check <the three changed Julia files in the parent diff>` -> exit 0.
- `typos <the five changed files in the parent diff>` and `git diff --check` for this stacked delta -> exit 0.
- `GROUP=BasicNeuralDE ... Pkg.test()` without the separate test-import patch -> `Neural DE | 241 / 241`; `Neural DAE | 2 existing broken / 2`; then `Neural ODE MM` errors only with `UndefVarError: BFGS`.
- The independent audit reproduced that exact file on clean master (`BFGS` error, 1/1) and passed it after importing from Optim (`Neural ODE Mass Matrix | 1 / 1`). With that direct-owner patch temporarily overlaid on this branch, the full group completed: `Neural DE | 241 / 241`, `Neural DAE | 2 existing broken / 2`, `Neural ODE MM | 1 / 1`, `Multiple Shooting | 1 existing broken / 1`, and `Testing DiffEqFlux tests passed`. The overlay was then removed; it is not part of this branch.

The local `Layers`, `Newton`, `AdvancedNeuralDE`, and `BasicNeuralDE` groups expose existing test imports that depended on Optimization wrapper reexports (`Adam`, `NewtonTrustRegion`, and `BFGS`). The Adam and NewtonTrustRegion failures reproduce on clean master; an independent audit is reproducing BFGS there and fixing all three directly through their owning packages. This compatibility-only handoff does not absorb that test-import fix. GPU, prerelease-Julia, and downstream lanes were not run locally.

This branch is based directly on the current upstream parent feature head `e0c2d62f` and contains only the one-line ADTypes floor correction.

AI continuation: OpenAI Codex session ID 01a03a11-47c2-77e0-858b-167004f0b79c.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
