### PR TITLE
Import test optimizers from their owning packages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -49,6 +49,7 @@ LuxCore = "1.5.2"
 LuxLib = "1.12.1"
 NNlib = "0.9.34"
 OneHotArrays = "0.2.10"
+Optim = "2"
 Optimisers = "0.4.7"
 Optimization = "5.5.1"
 OptimizationOptimJL = "0.4.14"
@@ -88,6 +89,7 @@ Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
 OneHotArrays = "0b1bfda6-eb8a-41d2-88d8-f5af5cad476f"
+Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 Optimisers = "3bd65402-5787-11e9-1adc-39752487f4e2"
 Optimization = "7f7a1694-90dd-40f0-9382-eb1efda571ba"
 OptimizationOptimJL = "36348300-93cb-4f02-beb5-3c3902f8871e"
@@ -108,4 +110,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "BenchmarkTools", "ComponentArrays", "DataInterpolations", "DelayDiffEq", "DiffEqCallbacks", "Distances", "Distributed", "DistributionsAD", "ForwardDiff", "Flux", "NNlib", "OneHotArrays", "Optimisers", "Optimization", "OptimizationOptimJL", "OptimizationOptimisers", "OrdinaryDiffEq", "OrdinaryDiffEqBDF", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqStabilizedRK", "Printf", "Random", "SafeTestsets", "SciMLTesting", "Statistics", "StochasticDiffEq", "Test", "Zygote"]
+test = ["Aqua", "BenchmarkTools", "ComponentArrays", "DataInterpolations", "DelayDiffEq", "DiffEqCallbacks", "Distances", "Distributed", "DistributionsAD", "ForwardDiff", "Flux", "NNlib", "OneHotArrays", "Optim", "Optimisers", "Optimization", "OptimizationOptimJL", "OptimizationOptimisers", "OrdinaryDiffEq", "OrdinaryDiffEqBDF", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqStabilizedRK", "Printf", "Random", "SafeTestsets", "SciMLTesting", "Statistics", "StochasticDiffEq", "Test", "Zygote"]

--- a/test/AdvancedNeuralDE/cnf_tests.jl
+++ b/test/AdvancedNeuralDE/cnf_tests.jl
@@ -1,6 +1,7 @@
 using DiffEqFlux, Lux, Zygote, Distances, Distributions, DistributionsAD, Optimization,
     LinearAlgebra, OrdinaryDiffEq, Random, Test, OptimizationOptimisers,
     Statistics, ComponentArrays
+using Optimisers: Adam
 
 Random.seed!(1999)
 

--- a/test/AdvancedNeuralDE/second_order_ode_tests.jl
+++ b/test/AdvancedNeuralDE/second_order_ode_tests.jl
@@ -1,5 +1,6 @@
 using DiffEqFlux, Lux, ComponentArrays, Zygote, Random, Optimization,
     OptimizationOptimisers, OrdinaryDiffEq, Test
+using Optimisers: Adam
 
 @testset "Second Order Neural ODE" begin
     rng = Xoshiro(0)

--- a/test/BasicNeuralDE/neural_ode_mm_tests.jl
+++ b/test/BasicNeuralDE/neural_ode_mm_tests.jl
@@ -1,5 +1,6 @@
 using DiffEqFlux, Lux, ComponentArrays, Zygote, Random, Optimization, OptimizationOptimJL,
     OrdinaryDiffEq, ADTypes, Test
+using Optim: BFGS
 using OrdinaryDiffEqRosenbrock: Rodas5
 
 @testset "Neural ODE Mass Matrix" begin

--- a/test/Layers/stiff_nested_ad_tests.jl
+++ b/test/Layers/stiff_nested_ad_tests.jl
@@ -1,5 +1,6 @@
 using DiffEqFlux, Lux, ComponentArrays, Zygote, OrdinaryDiffEq, Optimization,
     OptimizationOptimisers, Random, Test
+using Optimisers: Adam
 using OrdinaryDiffEqSDIRK: KenCarp4
 using OrdinaryDiffEqRosenbrock: Rodas5
 using OrdinaryDiffEqFIRK: RadauIIA5

--- a/test/Newton/newton_neural_ode_tests.jl
+++ b/test/Newton/newton_neural_ode_tests.jl
@@ -1,5 +1,6 @@
 using DiffEqFlux, Lux, ComponentArrays, Zygote, Optimization, OptimizationOptimJL,
     OrdinaryDiffEq, Random, Test
+using Optim: NewtonTrustRegion
 using OrdinaryDiffEqStabilizedRK: ROCK2, ROCK4
 
 @testset "Newton Neural ODE" begin


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

## What changed and why

The test suite used `Adam`, `BFGS`, and `NewtonTrustRegion` through the transitive export surface of Optimization wrapper packages. Current wrapper releases no longer export those constructors, so otherwise-valid test groups fail with `UndefVarError` before testing DiffEqFlux.

This imports each constructor from its public owner: `Adam` from Optimisers, and `BFGS`/`NewtonTrustRegion` from Optim. Optim is added only to `[extras]` and the test target, so this adds no runtime dependency. The change is independent of the public-API reexport work in https://github.com/SciML/DiffEqFlux.jl/pull/1054 and its compat follow-up https://github.com/SciML/DiffEqFlux.jl/pull/1055.

## Failing before the fix

All controls used clean DiffEqFlux master `5bc0b77fc62db7dedc7e595d5c71ec3f3365cccd` with Julia 1.12.6.

```text
$ GROUP=Layers julia +release --project=. -e 'using Pkg; Pkg.test()'
Collocation     | Pass 50 | Total 50
Stiff Nested AD | Error 3 | Total 3
UndefVarError: Adam not defined
ERROR: Package DiffEqFlux errored during testing

$ GROUP=AdvancedNeuralDE julia +release --project=. -e 'using Pkg; Pkg.test()'
UndefVarError: Adam not defined
Some tests did not pass: 0 passed, 0 failed, 21 errored, 4 broken.
ERROR: Package DiffEqFlux errored during testing

$ GROUP=Newton julia +release --project=. -e 'using Pkg; Pkg.test()'
Newton Neural ODE | Error 1 | Total 1
UndefVarError: NewtonTrustRegion not defined
ERROR: Package DiffEqFlux errored during testing

$ GROUP=BasicNeuralDE julia +release --project=. -e 'using Pkg; Pkg.test()'
Neural DE  | Pass 241 | Total 241
Neural DAE | Broken 2 | Total 2
Neural ODE MM            | Error 1 | Total 1
  Neural ODE Mass Matrix | Error 1 | Total 1
UndefVarError: BFGS not defined
ERROR: Package DiffEqFlux errored during testing
```

The isolated mass-matrix test also discriminates directly:

```text
$ julia +release --project=<Pkg.test environment> -e 'include("test/BasicNeuralDE/neural_ode_mm_tests.jl")'
Neural ODE Mass Matrix | Error 1 | Total 1
UndefVarError: BFGS not defined
```

For `Adam`, resolving OptimizationOptimisers 0.3.21 defines the binding and 0.3.22 does not; the declaring package is Optimisers. This is a dependency-surface change rather than a DiffEqFlux source regression.

## Passing after the fix

```text
$ GROUP=Layers julia +release --project=. -e 'using Pkg; Pkg.test()'
Collocation     | Pass 50 | Total 50
Stiff Nested AD | Pass 3  | Total 3
Testing DiffEqFlux tests passed

$ GROUP=AdvancedNeuralDE julia +release --project=. -e 'using Pkg; Pkg.test()'
CNF              | Pass 27 | Broken 4 | Total 31 | 48m10.9s
Second Order ODE | Pass 3  | Total 3  | 2m32.2s
Testing DiffEqFlux tests passed

$ GROUP=Newton julia +release --project=. -e 'using Pkg; Pkg.test()'
Newton Neural ODE | Pass 4 | Total 4
Testing DiffEqFlux tests passed

$ GROUP=BasicNeuralDE julia +release --project=. -e 'using Pkg; Pkg.test()'
Neural DE        | Pass 241 | Total 241 | 50m48.1s
Neural DAE       | Broken 2 | Total 2   | 1m10.4s
Neural ODE MM    | Pass 1   | Total 1   | 14m49.9s
Multiple Shooting | Broken 1 | Total 1
Testing DiffEqFlux tests passed

$ julia +release --project=<Pkg.test environment> -e 'include("test/BasicNeuralDE/neural_ode_mm_tests.jl")'
Neural ODE Mass Matrix | Pass 1 | Total 1 | 8m14.8s

$ GROUP=QA julia +release --project=. -e 'using Pkg; Pkg.test()'
QA | Pass 20 | Total 20 | 2m14.1s
Testing DiffEqFlux tests passed

$ julia +release --project=@runic -m Runic --check <changed Julia files>
$ typos <changed files>
$ git diff --check
# all exit 0 with no output
```

The first AdvancedNeuralDE attempt used a one-hour outer timeout: CNF completed with 27 passed and 4 pre-existing broken tests, then the timeout expired while Second Order ODE was still actively running. The complete retry above used the same declared group with a two-hour outer limit and passed.

## Dependency and verification scope

Optim 2.2.2's local `LICENSE.md` identifies the package as MIT-licensed, matching DiffEqFlux's permissive license. Compat `Optim = "2"` also matches OptimizationOptimJL's existing Optim 2 requirement. No `test/Project.toml` was created.

PublicInterface, CUDA/GPU, downstream packages, and documentation were not run locally. This patch touches only test imports and the root test extras/target; it does not change runtime or documented public API.

## Links

- Public-API reexport work: https://github.com/SciML/DiffEqFlux.jl/pull/1054
- Independent compat-floor follow-up: https://github.com/SciML/DiffEqFlux.jl/pull/1055
- Optim license: https://github.com/JuliaNLSolvers/Optim.jl/blob/master/LICENSE.md

AI agent continuation: OpenAI Codex
Codex-Session-ID: 01a03a11-47c2-77e0-858b-167004f0b79c

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
