### PR TITLE
test(CUDA): select the final saved solution state

### DIFF
--- a/test/CUDA/cuda_tests.jl
+++ b/test/CUDA/cuda_tests.jl
@@ -15,6 +15,8 @@ else
     const gdev = gpu_device()
     const cdev = cpu_device()
 
+    final_state((sol, _)) = last(sol.u)
+
     @testset "Neural DE CUDA" begin
         mp = Float32[0.1, 0.1] |> gdev
         x = Float32[2.0; 0.0] |> gdev
@@ -49,7 +51,7 @@ else
                         ndims(u0) == 2 &&
                         kwargs.sensealg isa TrackerAdjoint
                     @test begin
-                        grads = Zygote.gradient(sum ∘ last ∘ first ∘ node, u0, pd, st)
+                        grads = Zygote.gradient(sum ∘ final_state ∘ node, u0, pd, st)
                         CUDA.@allowscalar begin
                             !iszero(grads[1]) && !iszero(grads[2])
                         end
@@ -62,7 +64,7 @@ else
                     pd = ComponentArray(pd) |> gdev
                     st = st |> gdev
                     @test begin
-                        grads = Zygote.gradient(sum ∘ last ∘ first ∘ anode, u0, pd, st)
+                        grads = Zygote.gradient(sum ∘ final_state ∘ anode, u0, pd, st)
                         CUDA.@allowscalar begin
                             !iszero(grads[1]) && !iszero(grads[2])
                         end
@@ -87,7 +89,7 @@ else
             st = st |> gdev
 
             @test_broken begin
-                grads = Zygote.gradient(sum ∘ last ∘ first ∘ sode, u0, pd, st)
+                grads = Zygote.gradient(sum ∘ final_state ∘ sode, u0, pd, st)
                 CUDA.@allowscalar begin
                     !iszero(grads[1]) && !iszero(grads[2]) && !iszero(grads[2][end])
                 end


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

The CUDA gradient tests now select the final saved solution state with `last(sol.u)` instead of applying `last` to the `ODESolution` itself. RecursiveArrayTools 4 deliberately changed `AbstractVectorOfArray` linear indexing to standard `AbstractArray` semantics, so `last(sol)` now selects a scalar. That scalar selection is forbidden for a CUDA-backed saved state and caused all 22 live assertions in the CUDA job to error before reaching their gradient checks.

This is a test migration to the documented RecursiveArrayTools 4 interface; it does not change DiffEqFlux source behavior. The three affected NeuralODE, AugmentedNDELayer, and NeuralDSDE objectives share one local `final_state` helper.

## Root cause

- RecursiveArrayTools commit [`cde5c35`](https://github.com/SciML/RecursiveArrayTools.jl/commit/cde5c35ba194beb7b736ce5eb5f8de678efd6f66) removed the old `last(::AbstractVectorOfArray) = last(A.u)` behavior. Its [v4 migration guide](https://github.com/SciML/RecursiveArrayTools.jl/blob/v4.0.0/docs/src/breaking_changes_v4.md#first--last) says to use `last(A.u)` for the final inner array. The first containing package tag is [v4.0.0](https://github.com/SciML/RecursiveArrayTools.jl/releases/tag/v4.0.0).
- DiffEqFlux commit [`11d97f0`](https://github.com/SciML/DiffEqFlux.jl/commit/11d97f0a79bf3b7f857676b379b809f5c97d7876) first required SciMLBase 3.1; SciMLBase 3.1 requires RecursiveArrayTools 4. The CUDA objective written for the older semantics was not migrated.
- The [clean-master CUDA job](https://github.com/SciML/DiffEqFlux.jl/actions/runs/32118912771/job/95654618301) resolved RecursiveArrayTools 4.5.0 and ended with `22` errors and `7` broken tests. This PR is independent of [DiffEqFlux PR #1056](https://github.com/SciML/DiffEqFlux.jl/pull/1056); no changes from that PR are included.

## Failing before / passing after

The machine has no NVIDIA device (`nvidia-smi` is absent and `/dev/nvidia*` does not exist), so I reproduced the GPU scalar-indexing rule on the CPU-backed JLArrays GPUArrays implementation. The same objective was run against the last v3 release and the first v4 release:

```text
RecursiveArrayTools=3.54.0
old_loss=PASS gradient=Float32[1.0, 1.0]
migrated_loss=PASS gradient=Float32[1.0, 1.0]

RecursiveArrayTools=4.0.0
old_loss=FAIL Scalar indexing is disallowed.
migrated_loss=PASS gradient=Float32[1.0, 1.0]
```

The current clean-master CUDA failure has the same Zygote pullback path through `last(::ODESolution)`:

```text
Scalar indexing is disallowed.
Invocation of getindex resulted in scalar indexing of a GPU array.
[5] _pullback(ctx::Zygote.Context{false}, f::typeof(last), args::SciMLBase.ODESolution{...CuArray...})

Test Summary:  | Error  Broken  Total
  Neural DE CUDA | 22       7     29
```

## Local verification

```text
GROUP=QA JULIA_DEPOT_PATH="$PWD/.depot-qa:/home/crackauc/.julia" TMPDIR="$PWD/.task-tmp/qa" julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   20     20  3m23.0s
Testing DiffEqFlux tests passed

GROUP=PublicInterface JULIA_DEPOT_PATH="$PWD/.depot-basic:/home/crackauc/.julia" TMPDIR="$PWD/.task-tmp/public-interface" julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary:     | Pass  Total     Time
Public interfaces |   45     45  1m14.9s
Testing DiffEqFlux tests passed

GROUP=CUDA JULIA_DEPOT_PATH="$PWD/.depot-cuda:/home/crackauc/.julia" TMPDIR="$PWD/.task-tmp/cuda" julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Warning: LuxCUDA is loaded but the CUDA GPU is not functional.
Info: CUDA not functional, skipping CUDA tests
Test Summary: | Broken  Total   Time
CUDA          |      1      1  25.7s
Testing DiffEqFlux tests passed

julia +1.12 --startup-file=no --project=@runic -m Runic --check test/CUDA/cuda_tests.jl
typos test/CUDA/cuda_tests.jl
git diff --check
# all exited 0
```

The full CPU `GROUP=BasicNeuralDE` run also reached `Neural DE | 241/241` in 55m23s, then stopped in the unrelated clean-master `Neural ODE MM` test because bare `BFGS` is no longer in scope. That direct-owner Optim import fallout is being fixed separately and is not included here.

An actual NVIDIA CUDA pass-after could not be run locally because this host has no GPU. CI must provide that hardware validation. Documentation was not built because this is a test-only change with no public API or documentation changes.

AI-Agent: OpenAI Codex
Codex-Session-ID: 01a03a11-47c2-77e0-858b-167004f0b79c

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
