### PR TITLE
test: import BFGS from Optim

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -49,6 +49,7 @@ LuxCore = "1.5.2"
 LuxLib = "1.12.1"
 NNlib = "0.9.34"
 OneHotArrays = "0.2.10"
+Optim = "2"
 Optimisers = "0.4.7"
 Optimization = "5.5.1"
 OptimizationOptimJL = "0.4.14"
@@ -88,6 +89,7 @@ Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
 OneHotArrays = "0b1bfda6-eb8a-41d2-88d8-f5af5cad476f"
+Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 Optimisers = "3bd65402-5787-11e9-1adc-39752487f4e2"
 Optimization = "7f7a1694-90dd-40f0-9382-eb1efda571ba"
 OptimizationOptimJL = "36348300-93cb-4f02-beb5-3c3902f8871e"
@@ -108,4 +110,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "BenchmarkTools", "ComponentArrays", "DataInterpolations", "DelayDiffEq", "DiffEqCallbacks", "Distances", "Distributed", "DistributionsAD", "ForwardDiff", "Flux", "NNlib", "OneHotArrays", "Optimisers", "Optimization", "OptimizationOptimJL", "OptimizationOptimisers", "OrdinaryDiffEq", "OrdinaryDiffEqBDF", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqStabilizedRK", "Printf", "Random", "SafeTestsets", "SciMLTesting", "Statistics", "StochasticDiffEq", "Test", "Zygote"]
+test = ["Aqua", "BenchmarkTools", "ComponentArrays", "DataInterpolations", "DelayDiffEq", "DiffEqCallbacks", "Distances", "Distributed", "DistributionsAD", "ForwardDiff", "Flux", "NNlib", "OneHotArrays", "Optim", "Optimisers", "Optimization", "OptimizationOptimJL", "OptimizationOptimisers", "OrdinaryDiffEq", "OrdinaryDiffEqBDF", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqStabilizedRK", "Printf", "Random", "SafeTestsets", "SciMLTesting", "Statistics", "StochasticDiffEq", "Test", "Zygote"]

--- a/test/BasicNeuralDE/neural_dae_tests.jl
+++ b/test/BasicNeuralDE/neural_dae_tests.jl
@@ -1,5 +1,6 @@
 using DiffEqFlux, Lux, ComponentArrays, Zygote, Optimization, OptimizationOptimJL,
     OrdinaryDiffEq, Random, Test
+using Optim: BFGS
 using OrdinaryDiffEqRosenbrock: Rodas5
 using OrdinaryDiffEqBDF: DFBDF, DImplicitEuler
 

--- a/test/BasicNeuralDE/neural_ode_mm_tests.jl
+++ b/test/BasicNeuralDE/neural_ode_mm_tests.jl
@@ -1,5 +1,6 @@
 using DiffEqFlux, Lux, ComponentArrays, Zygote, Random, Optimization, OptimizationOptimJL,
     OrdinaryDiffEq, ADTypes, Test
+using Optim: BFGS
 using OrdinaryDiffEqRosenbrock: Rodas5
 
 @testset "Neural ODE Mass Matrix" begin


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

The BasicNeuralDE tests now import `BFGS` directly from its owning package, Optim. Optim is declared as a test dependency with the same major-version constraint already required by OptimizationOptimJL.

OptimizationOptimJL still supplies the `Optimization.solve` integration. The tests no longer rely on that wrapper transitively reexporting all of Optim's public names.

## Root cause

Optimization commit [`0c726c0c`](https://github.com/SciML/Optimization.jl/commit/0c726c0cf0b2f4c150b26ca03c4117e8a35434af) removed `@reexport using Optim` from OptimizationOptimJL. The change first shipped in [OptimizationOptimJL v0.4.19](https://github.com/SciML/Optimization.jl/releases/tag/OptimizationOptimJL-v0.4.19); v0.4.18 still supplied bare `BFGS` as a side effect of loading the wrapper.

The exact dependency transition reproduces independently of DiffEqFlux:

```text
OptimizationOptimJL=0.4.18
bare_BFGS=true
bare_constructor=BFGS{...}(...)
owner=Optim

OptimizationOptimJL=0.4.19
bare_BFGS=false
bare_constructor=FAIL UndefVarError: `BFGS` not defined in `Main`
owner_import=BFGS{...}(...)
owner=Optim
```

Optim 2.2.2 exports and documents `BFGS`, and `parentmodule(Optim.BFGS) === Optim`. Optim and DiffEqFlux are both MIT-licensed. The broader wrapper reexport restoration is tracked separately in [Optimization PR #1315](https://github.com/SciML/Optimization.jl/pull/1315); this direct-owner import remains correct independently of that PR.

## Failing before / passing after

On an unmodified checkout of DiffEqFlux master at `5bc0b77fc62db7dedc7e595d5c71ec3f3365cccd`, the focused mass-matrix test failed:

```text
UndefVarError: `BFGS` not defined in `Main`
Hint: a global variable of this name also exists in Optim.
@ test/BasicNeuralDE/neural_ode_mm_tests.jl:53

Test Summary:          | Error  Total   Time
Neural ODE Mass Matrix |     1      1  38.6s
```

With this patch, the same test executes the optimization and passes:

```text
Test Summary:          | Pass  Total     Time
Neural ODE Mass Matrix |    1      1  8m38.9s
```

The two existing NeuralDAE tests also now reach their intended underlying broken paths instead of breaking merely because `BFGS` is absent:

```text
Test Summary: | Broken  Total     Time
Neural DAE    |      2      2  1m09.6s
```

## Local verification

```text
GROUP=QA JULIA_DEPOT_PATH="$PWD/../diffeqflux-cuda-main/.depot-qa:/home/crackauc/.julia" TMPDIR="$PWD/.task-tmp/qa" julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   20     20  4m21.4s
Testing DiffEqFlux tests passed

GROUP=BasicNeuralDE JULIA_DEPOT_PATH="$PWD/../diffeqflux-cuda-main/.depot-basic:/home/crackauc/.julia" TMPDIR="$PWD/.task-tmp/basic" julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total      Time
Neural DE     |  241    241  51m37.7s
Test Summary: | Broken  Total     Time
Neural DAE    |      2      2  1m54.1s
Test Summary: | Pass  Total      Time
Neural ODE MM |    1      1  20m01.7s
Test Summary:     | Broken  Total  Time
Multiple Shooting |      1      1  0.0s
Testing DiffEqFlux tests passed

julia +1.12 --startup-file=no --project=@runic -m Runic --check test/BasicNeuralDE/neural_dae_tests.jl test/BasicNeuralDE/neural_ode_mm_tests.jl
typos Project.toml test/BasicNeuralDE/neural_dae_tests.jl test/BasicNeuralDE/neural_ode_mm_tests.jl
git diff --check
# all exited 0
```

Documentation was not built because this changes only test dependencies and test imports, with no source, public API, docstring, or documentation changes.

AI-Agent: OpenAI Codex
Codex-Session-ID: 01a03a11-47c2-77e0-858b-167004f0b79c

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
