### PR TITLE
qa: use shared reexport documentation policy

### DIFF
--- a/test/QA/qa_tests.jl
+++ b/test/QA/qa_tests.jl
@@ -33,9 +33,6 @@ const REEXPORTS = (
 run_qa(
     DiffEqFlux;
     reexports_allow = REEXPORTS,
-    # `SamePad` is exported by Lux without a docstring (LuxDL/Lux.jl); drop the ignore
-    # once Lux documents it.
-    api_docs_kwargs = (; ignore = (:SamePad,)),
     # `ambiguities = false` in test_all + a separate non-recursive ambiguity check
     # historically; keep ambiguities on but non-recursive (recursive hits the deep
     # Lux/SciMLSensitivity stack and is not DiffEqFlux's responsibility).


### PR DESCRIPTION
Removes the repository-local public-doc exception for `Lux.SamePad`, an explicitly allow-listed DiffEqFlux facade reexport documented by its owning package. This depends on https://github.com/SciML/SciMLTesting.jl/pull/62.

Ignore until reviewed by @ChrisRackauckas.

## Verification

- `git diff --check`
- `typos test/QA/qa_tests.jl`
- Strict QA with the SciMLTesting source from PR 62: `Quality Assurance | 20 / 20`; `Reexport surface | 142 / 142`
- `julia --startup-file=no --project=docs docs/make.jl` completed successfully. Documenter emitted only existing repository-link/deployment warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/019f4028-d2ae-7a12-aff0-7d996bd9c791