### PR TITLE
ci: stabilize grouped CPU test jobs

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -3,12 +3,19 @@ versions = ["lts", "1"]
 
 [BasicNeuralDE]
 versions = ["lts", "1"]
+runner = "ubuntu-24.04"
+timeout = 240
 
 [AdvancedNeuralDE]
 versions = ["lts", "1"]
+runner = "ubuntu-24.04"
+timeout = 360
 
 [Newton]
 versions = ["lts", "1"]
 
 [QA]
+versions = ["lts", "1"]
+
+[PublicInterface]
 versions = ["lts", "1"]


### PR DESCRIPTION
Please ignore this draft until it has been reviewed by @ChrisRackauckas.

## What changed and why

The grouped CPU workflow now schedules `PublicInterface` on Julia LTS and latest, gives `BasicNeuralDE` a 240-minute bound, and gives `AdvancedNeuralDE` a 360-minute bound. The two heavy neural-DE groups explicitly request `ubuntu-24.04`, which the central grouped workflow accepts and keeps these jobs off the self-hosted `ubuntu-latest` label.

The existing shared 120-minute bound canceled the current AdvancedNeuralDE LTS job during CNF, while a recent LTS downgrade job needed 157m27.1s for CNF alone. A current BasicNeuralDE latest job also reached the shared bound and was canceled during Neural ODE MM. This is CI scheduling/configuration only; it does not change package or test behavior.

## Verification

All local test commands used Julia 1.12.7, one Julia thread, one precompile task, a branch-local first depot, and Bash `timeout` bounds of at least two hours.

Central grouped-workflow parser, at SciML/.github commit `d5748d7f7e95749cb0a5acaed6e69162623be862`:

```text
AdvancedNeuralDE lts/1: runner=ubuntu-24.04 timeout=360
BasicNeuralDE lts/1: runner=ubuntu-24.04 timeout=240
PublicInterface lts/1: runner=ubuntu-latest timeout=120
```

The exact parser command was:

```sh
julia --startup-file=no /home/crackauc/sandbox/tmp_20260830_004101_20933/SciML-dotgithub-v1/scripts/compute_affected_sublibraries.jl . --root-matrix
```

TOML assertions:

```text
TOML validation passed: AdvancedNeuralDE, BasicNeuralDE, Layers, Newton, PublicInterface, QA
```

Formatting, spelling, and diff checks all exited 0 with no diagnostics:

```sh
julia --startup-file=no -m Runic --check .
git diff --name-only HEAD^ | typos --file-list -
git diff HEAD^ --check
```

`GROUP=PublicInterface` (initial isolated run):

```text
Public interfaces | 45 passed, 45 total, 1m19.1s
Testing DiffEqFlux tests passed
real 783.11s
```

`GROUP=PublicInterface` (required post-fetch run):

```text
Public interfaces | 45 passed, 45 total, 3m59.2s
Testing DiffEqFlux tests passed
real 265.78s
```

`GROUP=BasicNeuralDE`, bounded by `timeout 14400`:

```text
Neural DE          | 241 passed, 241 total, 48m28.7s
Neural DAE         | 2 broken, 2 total, 1m26.6s
Neural ODE MM      | 1 passed, 1 total, 12m31.3s
Multiple Shooting | 1 broken, 1 total, 0.0s
Testing DiffEqFlux tests passed
real 3771.88s
```

`GROUP=AdvancedNeuralDE`, bounded by the configured `timeout 21600`:

```text
CNF              | 27 passed, 4 broken, 31 total, 54m38.0s
Second Order ODE | 3 passed, 3 total, 2m19.6s
Testing DiffEqFlux tests passed
real 3446.50s
```

The broken cases above are existing test annotations and are not counted as passes.

## Post-push CI verification

The changed matrix and timeouts were exercised in CI:

```text
BasicNeuralDE latest | passed | 58m21s
BasicNeuralDE LTS    | passed | 30m15s
PublicInterface latest | passed | 15m38s
PublicInterface LTS    | passed | 8m16s
AdvancedNeuralDE latest | passed | 55m51s
AdvancedNeuralDE LTS    | passed | 2h23m36s
  CNF | 27 passed, 4 broken, 31 total, 133m03.2s
  Second Order ODE | 3 passed, 3 total, 1m06.5s
Downgrade AdvancedNeuralDE | passed | 2h08m42s
  CNF | 27 passed, 4 broken, 31 total, 119m40.0s
  Second Order ODE | 3 passed, 3 total, 1m05.5s
```

Both LTS/downgrade Advanced jobs exceeded the previous 120-minute limit and completed under the new 360-minute bound.

## QA baseline evidence

`GROUP=QA` did not pass locally. Two isolated-depot runs each reported 160 passed and 2 failed out of 162: Aqua persistent-task detection (2m58.9s, then 2m49.7s) and Aqua's missing-docstring check for `DiffEqFlux.SamePad`. Wall times were 3405.72s and 1498.23s, respectively.

An independent clean checkout of current upstream master ran `GROUP=QA` three times: persistent-task detection passed all three times, while the `SamePad` missing-docstring failure reproduced each time (`QA | 161 passed, 1 failed, 162 total`). Current upstream CI independently shows the same `SamePad`-only baseline failure. This TOML-only change does not alter either QA path.

## Not run

Docs were not built because this change touches neither documentation nor public API. GPU, downstream, and allowed-to-fail jobs were not run locally.

## Links

- AdvancedNeuralDE LTS canceled at the shared limit: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33106209948/job/98641491536
- AdvancedNeuralDE latest completed in the same run: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33106209948/job/98641491591
- Recent LTS downgrade CNF took 157m27.1s: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33106209794/job/98636623294
- BasicNeuralDE latest canceled during Neural ODE MM: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33104907664/job/98637384830
- Current upstream SamePad-only QA failure: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33106209948/job/98641491488
- Passing PR AdvancedNeuralDE LTS job: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33297624071/job/99220146222
- Passing PR downgrade AdvancedNeuralDE job: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33297623837/job/99219896868
- Passing PR grouped CPU matrix: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33297624071
- Central grouped workflow parser/schema: https://github.com/SciML/.github/blob/d5748d7f7e95749cb0a5acaed6e69162623be862/.github/workflows/tests.yml

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: `/home/crackauc/.codex/sessions/2026/08/29/rollout-2026-08-29T20-41-15-01a0501d-0879-7f80-b479-de442568c09d.jsonl`, local transcript path)

