### PR TITLE
Format multiline generator for Runic 1.10

### DIFF
--- a/src/multiple_shooting.jl
+++ b/src/multiple_shooting.jl
@@ -72,14 +72,14 @@ function multiple_shoot(
     # Multiple shooting predictions
     sols = [
         solve(
-                remake(
-                    prob; p, tspan = (tsteps[first(rg)], tsteps[last(rg)]),
-                    u0 = ode_data[griddims..., first(rg)]
-                ),
-                solver;
-                saveat = tsteps[rg],
-                kwargs...
-            ) for rg in ranges
+            remake(
+                prob; p, tspan = (tsteps[first(rg)], tsteps[last(rg)]),
+                u0 = ode_data[griddims..., first(rg)]
+            ),
+            solver;
+            saveat = tsteps[rg],
+            kwargs...
+        ) for rg in ranges
     ]
     group_predictions = Array.(sols)
 


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Runic 1.10.0 corrected indentation for multiline element expressions in generators, exposing one pre-existing formatting difference in `src/multiple_shooting.jl`. This PR applies the exact Runic 1.10.0 output. It is a mechanical whitespace-only change with no behavior, API, or dependency changes.

The floating `runic-version: "1"` CI input began resolving to Runic 1.10.0 on 2026-08-30. The first failing CI job is https://github.com/SciML/DiffEqFlux.jl/actions/runs/33297623907/job/99219896589.

## Failing before / passing after

On clean upstream `master` at `ff70967eb5f5574baebeb269dec06f9432331451`:

```text
runic version 1.9.0, julia version 1.12.7
Runic --check src/multiple_shooting.jl: exit 0

runic version 1.10.0, julia version 1.12.7
Runic --check src/multiple_shooting.jl: exit 1
```

After this commit:

```text
runic version 1.10.0, julia version 1.12.7
Runic --check over all 22 tracked Julia files: exit 0
```

A bisect of Runic `v1.9.0..v1.10.0` against the unchanged DiffEqFlux file identified https://github.com/fredrikekre/Runic.jl/commit/8345856ec3c4f4d24c0ae50cf9d01f20aa6e1719 as the first output-changing commit. That commit intentionally fixes indentation of multiline generator element expressions.

## Verification

```text
env TMPDIR=... julia +1.12 --startup-file=no --project=<Runic-1.10-env> -m Runic --check $(git ls-files '*.jl')
exit 0

git diff --unified=0 upstream/master...HEAD | typos -
exit 0

git diff --check upstream/master...HEAD
exit 0

GROUP=BasicNeuralDE julia +1.12 --startup-file=no --color=no --project=. -e 'using Pkg; Pkg.test()'
Neural DE: 241 passed / 241 total (47m08.5s)
Neural DAE: 2 pre-existing broken / 2 total (1m27.1s)
Neural ODE MM: 1 passed / 1 total (12m07.0s)
Multiple Shooting: 1 pre-existing broken / 1 total; skipped for https://github.com/SciML/DiffEqFlux.jl/issues/1004
Package tests passed; exit 0
```

`GROUP=QA` was also run. It completed with 160 passed and 2 failed out of 162 in 6m55.4s. Both failures reproduce independently of this whitespace-only change: the known `SamePad` dependency documentation failure and a non-reproducible Aqua persistent-task artifact. The latter passed in three clean-master reruns and in current master CI; current master CI fails only on `SamePad`: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33106209948/job/98641491488.

## Not verified

Docs were not rebuilt because this PR changes neither documentation nor public API. CUDA, downstream, and allowed-to-fail jobs were not run locally.

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol).
Session: `/home/crackauc/.codex/sessions/2026/08/29/rollout-2026-08-29T20-41-15-01a0501d-0879-7f80-b479-de442568c09d.jsonl` (local transcript path; no shareable URL was exposed).
