### PR TITLE
Stop reexporting Lux.SamePad

### DIFF
--- a/docs/src/reexports.md
+++ b/docs/src/reexports.md
@@ -22,8 +22,7 @@ The `Lux` module itself is re-exported (so `Lux.setup`, `Lux.Chain`, ... work), 
 with the layers used by this documentation:
 
   - Containers and basic layers: `Chain`, `Dense`, `WrappedFunction`
-  - Convolutional and pooling layers: `Conv`, `MaxPool`, `MeanPool`, `FlattenLayer`,
-    `SamePad`
+  - Convolutional and pooling layers: `Conv`, `MaxPool`, `MeanPool`, `FlattenLayer`
   - Normalization: `GroupNorm`
   - Stateful wrapper: `StatefulLuxLayer`
   - Flux interop: `FromFluxAdaptor`

--- a/src/DiffEqFlux.jl
+++ b/src/DiffEqFlux.jl
@@ -35,6 +35,14 @@ const CRC = ChainRulesCore
 #   * the `Layers`/`Basis` model zoo modules from Boltz.
 using Lux: Conv, FlattenLayer, GroupNorm, MaxPool, MeanPool, SamePad, Training,
     WrappedFunction, f32, f64
+
+"""
+    SamePad()
+
+Lux padding mode that keeps convolutional spatial size unchanged.
+Reexported from Lux.
+"""
+SamePad
 using LuxCore: apply, initialparameters, initialstates, parameterlength, setup,
     statelength, testmode, trainmode
 using ADTypes: AbstractADType, AutoChainRules, AutoDiffractor, AutoEnzyme,

--- a/src/DiffEqFlux.jl
+++ b/src/DiffEqFlux.jl
@@ -33,16 +33,8 @@ const CRC = ChainRulesCore
 #   * the layer contract (`setup`, `apply`, ...) from LuxCore,
 #   * the `Auto*` differentiation selectors from ADTypes,
 #   * the `Layers`/`Basis` model zoo modules from Boltz.
-using Lux: Conv, FlattenLayer, GroupNorm, MaxPool, MeanPool, SamePad, Training,
+using Lux: Conv, FlattenLayer, GroupNorm, MaxPool, MeanPool, Training,
     WrappedFunction, f32, f64
-
-"""
-    SamePad()
-
-Lux padding mode that keeps convolutional spatial size unchanged.
-Reexported from Lux.
-"""
-SamePad
 using LuxCore: apply, initialparameters, initialstates, parameterlength, setup,
     statelength, testmode, trainmode
 using ADTypes: AbstractADType, AutoChainRules, AutoDiffractor, AutoEnzyme,
@@ -82,7 +74,7 @@ export TrackerVJP, ZygoteVJP, EnzymeVJP, ReverseDiffVJP
 
 # Reexported neural-network construction surface; approved via `reexports_allow` in
 # test/QA/qa_tests.jl and documented in docs/src/reexports.md.
-export Lux, Chain, Dense, Conv, MaxPool, MeanPool, FlattenLayer, GroupNorm, SamePad,
+export Lux, Chain, Dense, Conv, MaxPool, MeanPool, FlattenLayer, GroupNorm,
     WrappedFunction, StatefulLuxLayer, FromFluxAdaptor, Training, f32, f64
 export LuxCore, AbstractLuxLayer, AbstractLuxContainerLayer, AbstractLuxWrapperLayer,
     setup, apply, initialparameters, initialstates, parameterlength, statelength,

--- a/test/QA/qa_tests.jl
+++ b/test/QA/qa_tests.jl
@@ -15,7 +15,7 @@ const REEXPORTS = (
     :TrackerVJP, :ZygoteAdjoint, :ZygoteVJP,
     # Lux: network construction.
     :Chain, :Conv, :Dense, :FlattenLayer, :FromFluxAdaptor, :GroupNorm, :Lux, :MaxPool,
-    :MeanPool, :SamePad, :StatefulLuxLayer, :Training, :WrappedFunction, :f32, :f64,
+    :MeanPool, :StatefulLuxLayer, :Training, :WrappedFunction, :f32, :f64,
     # LuxCore: the layer contract.
     :AbstractLuxContainerLayer, :AbstractLuxLayer, :AbstractLuxWrapperLayer, :LuxCore,
     :apply, :initialparameters, :initialstates, :parameterlength, :setup, :statelength,


### PR DESCRIPTION
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

Do not reexport `Lux.SamePad`. It is undocumented upstream, DiffEqFlux does not use it, and the MNIST conv example already does `using DiffEqFlux, Lux`.

## Verification

Fail-before (SamePad still reexported, no local docstring):

```
public API has docstrings: Test Failed
Evaluated: isempty([:SamePad])
QA | 161 pass, 1 fail
```

Pass-after (SamePad not reexported):

```
QA | 160 pass
Testing DiffEqFlux tests passed
```

The two missing counts vs the 162-with-docstring run are the per-name reexport-surface tests for \`SamePad\`.

## What was not verified

- CUDA / GPU jobs (pre-existing TrackerAdjoint failures)
- Downgrade QA
- BasicNeuralDE / AdvancedNeuralDE / Newton / Layers groups

🤖 Generated with Grok Build TUI 1.0.13 (model: grok-4.6)

Session: local \`01a05208-1801-7323-a40d-daf68951e609\` (transcript \`/home/crackauc/.grok/sessions/%2Fhome%2Fcrackauc%2Fsandbox%2Ftmp_20260830_093701_61089/01a05208-1801-7323-a40d-daf68951e609\`).