### PR TITLE
Document the SamePad reexport

### DIFF
--- a/src/DiffEqFlux.jl
+++ b/src/DiffEqFlux.jl
@@ -35,6 +35,14 @@ const CRC = ChainRulesCore
 #   * the `Layers`/`Basis` model zoo modules from Boltz.
 using Lux: Conv, FlattenLayer, GroupNorm, MaxPool, MeanPool, SamePad, Training,
     WrappedFunction, f32, f64
+
+"""
+    SamePad()
+
+Lux padding mode that computes convolutional or pooling padding from the kernel size and
+dilation. Reexported from Lux.
+"""
+SamePad
 using LuxCore: apply, initialparameters, initialstates, parameterlength, setup,
     statelength, testmode, trainmode
 using ADTypes: AbstractADType, AutoChainRules, AutoDiffractor, AutoEnzyme,


### PR DESCRIPTION
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Attach a local docstring to DiffEqFlux's existing `SamePad` reexport. `SamePad` is exported and public in Lux but has no owner docstring, so restoring DiffEqFlux's established reexport in https://github.com/SciML/DiffEqFlux.jl/pull/1069 made the public-API documentation check fail. A local docstring preserves the non-breaking export surface and avoids a QA ignore.

## Verification

Failing before on clean `master` at `5342b39da22834ab136ecab3f514e2045f99ea86`:

```text
GROUP=QA julia +release --project=. -e 'using Pkg; Pkg.test()'
public API has docstrings: Test Failed
Evaluated: isempty([:SamePad])
QA | 161 passed, 1 failed, 162 total
Persistent tasks | 1 passed, 1 total
```

Passing after:

```text
GROUP=QA julia +release --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |  162    162  2m31.9s
Testing DiffEqFlux tests passed
```

The clean master run also passed Aqua's persistent-task check in 2m20.0s. The isolated hosted `done.log` failure was therefore not reproduced and is not suppressed here.

```text
julia +release --project=docs -e 'using Pkg; Pkg.instantiate()'
julia +release --project=docs docs/make.jl
[ Info: Doctest: running doctests.
[ Info: CheckDocument: running document checks.
[ Info: RenderDocument: rendering document.
[ Info: HTMLWriter: rendering HTML pages.
```

```text
julia +release -m Runic --check src/DiffEqFlux.jl
git diff --name-only --diff-filter=ACMR | typos --file-list -
git diff --check
```

All three commands exited successfully.

I also verified the resolved Lux 1.31.4 binding directly:

```text
exported=true
public=true
doc_binding_present=false
```

## Not verified

No NVIDIA GPU or `nvidia-smi` is available locally. This documentation-only change does not touch GPU behavior.

## Links

- SamePad reexport restoration: https://github.com/SciML/DiffEqFlux.jl/pull/1069
- Failing master QA job: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33395017376/job/99512160317

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: local session ID 01a0598f-11b9-72d1-91d9-b2fbb186557d)
