### PR TITLE
Raise the ADTypes compat floor to 1.22.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,7 @@ DataInterpolations = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
 DiffEqFluxDataInterpolationsExt = "DataInterpolations"
 
 [compat]
-ADTypes = "1.22"
+ADTypes = "1.22.3"
 Aqua = "0.8.16"
 BenchmarkTools = "1.5.0"
 Boltz = "1.7"


### PR DESCRIPTION
> [!IMPORTANT]
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Raise the ADTypes compatibility floor from 1.22 to 1.22.3. DiffEqFlux deliberately reexports the public `AutoModelingToolkit` selector, but ADTypes 1.22.0 through 1.22.2 do not attach a docstring to it. ADTypes 1.22.3 is the first registered release that does, so the older floor makes DiffEqFlux's public-API documentation audit fail only under downgrade resolution.

This is a one-line mechanical compatibility change. It does not change the reexport surface, duplicate owner documentation, or add a QA ignore.

## Root cause and bisect

A clean `git bisect` from the pre-reexport commit `4500140` to current master identifies https://github.com/SciML/DiffEqFlux.jl/commit/7c70c5e91b5e874d55d10e029da62b22194bb1d9 as the first bad commit. That commit began explicitly importing/exporting `AutoModelingToolkit` while setting the ADTypes floor to the broad `1.22`.

ADTypes added the owner docstring in https://github.com/SciML/ADTypes.jl/commit/b061cc8a6868a02edaac07a6c9d4854c066da1f4. Direct checks of each registered 1.22 patch show the release boundary:

```text
ADTypes 1.22.0: doc missing = true
ADTypes 1.22.1: doc missing = true
ADTypes 1.22.2: doc missing = true
ADTypes 1.22.3: doc missing = false
```

The narrow SemVer-preserving fix is therefore to require 1.22.3 while keeping the public reexport and its documentation owned by ADTypes.

## Failing before

I reproduced the reusable downgrade workflow from a clean current-master checkout (`5342b39`, DiffEqFlux 4.10.2) with Julia 1.10.12, `julia-actions/julia-downgrade-compat@v2` in `deps` mode, the computed standard-library skip list, and `Mooncake` as the force-latest exception. After the resolver/build step I restored the original `Project.toml` and ran locked QA without re-resolution.

The unmodified floor selected ADTypes 1.22.0:

```text
public API has docstrings: Test Failed
Evaluated: isempty([:AutoModelingToolkit, :SamePad])
QA | 159 pass | 1 fail | 160 total | 7m35.6s
Persistent tasks | 1 pass | 1 total | 4m49.0s
```

## Passing after for this change

The hosted downgrade resolver on this branch selects ADTypes 1.22.3. Its only undocumented name is the independent current-master `SamePad` owner-doc gap; `AutoModelingToolkit` is absent from the failure set:

```text
ADTypes v1.22.3
Evaluated: isempty([:SamePad])
QA | 159 pass | 1 fail | 160 total | 5m56.6s
Persistent tasks | 1 pass | 1 total | 3m29.2s
```

That hosted discriminator is at https://github.com/SciML/DiffEqFlux.jl/actions/runs/33454317052/job/99690893108.

For a fully green local after-run, I also tested this exact one-line compat diff in a temporary composition with the isolated SamePad documentation commit formerly proposed in https://github.com/SciML/DiffEqFlux.jl/pull/1072. That PR was closed after review and is not part of this branch; the composition was used only to remove the independent failure while validating this compat change.

```text
ADTypes 1.22.3: AutoModelingToolkit documented=true
QA | 160 pass | 160 total | 5m54.4s
Testing DiffEqFlux tests passed
```

Exact locked QA form used for the before/after workflow reproduction:

```sh
GROUP=QA julia +1.10 --project=. -e 'import Pkg; Pkg.test(; force_latest_compatible_version=false, allow_reresolve=false)'
```

Additional local gates:

```text
julia +release -m Runic --check .  # exit 0
typos Project.toml                 # exit 0
git diff --check                   # exit 0
```

## Hosted CI context

All current CPU test groups, Runic, typos, and the four non-QA downgrade groups completed successfully. The remaining red checks are independent of this compat-only diff:

- Current-dependency QA reports `SamePad` plus an Aqua subprocess transient: `/tmp/.../done.log was not created, but precompilation exited`. The exact clean downgrade run above and other clean current-dependency QA reproductions complete the persistent-task check, so Aqua has not been disabled or silenced. Job: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33454317118/job/99690954775.
- CUDA reports six unexpected passes from pre-existing broken Tracker-adjoint expectations (`22 passed, 6 errored, 1 broken`); no CUDA test or GPU dependency is changed here. Job: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33454316571/job/99690891560.
- A docs build is not applicable because this PR changes neither a docstring nor public API; GitHub correctly skipped that path-filtered job.

## Links

- This PR: https://github.com/SciML/DiffEqFlux.jl/pull/1073
- Original downgrade QA failure: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33395017130/job/99497359530
- Hosted after discriminator: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33454317052/job/99690893108
- DiffEqFlux introducing commit: https://github.com/SciML/DiffEqFlux.jl/commit/7c70c5e91b5e874d55d10e029da62b22194bb1d9
- ADTypes owner-doc commit: https://github.com/SciML/ADTypes.jl/commit/b061cc8a6868a02edaac07a6c9d4854c066da1f4
- ADTypes 1.22.3 release PR: https://github.com/SciML/ADTypes.jl/pull/169
- Closed SamePad documentation proposal used only for temporary composition: https://github.com/SciML/DiffEqFlux.jl/pull/1072

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: local session ID 01a0598f-11b9-72d1-91d9-b2fbb186557d)
