### PR TITLE
Promote passing CUDA Tracker assertions

### DIFF
--- a/test/CUDA/cuda_tests.jl
+++ b/test/CUDA/cuda_tests.jl
@@ -47,15 +47,12 @@ else
                     pd, st = Lux.setup(rng, node)
                     pd = ComponentArray(pd) |> gdev
                     st = st |> gdev
-                    broken = hasfield(typeof(kwargs), :sensealg) &&
-                        ndims(u0) == 2 &&
-                        kwargs.sensealg isa TrackerAdjoint
                     @test begin
                         grads = Zygote.gradient(sum ∘ final_state ∘ node, u0, pd, st)
                         CUDA.@allowscalar begin
                             !iszero(grads[1]) && !iszero(grads[2])
                         end
-                    end broken = broken
+                    end
 
                     anode = AugmentedNDELayer(
                         NeuralODE(aug_dudt, tspan, Tsit5(); kwargs...), 2
@@ -68,7 +65,7 @@ else
                         CUDA.@allowscalar begin
                             !iszero(grads[1]) && !iszero(grads[2])
                         end
-                    end broken = broken
+                    end
                 end
             end
         end


### PR DESCRIPTION
> [!IMPORTANT]
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Promote the six matrix-input `TrackerAdjoint` CUDA gradient checks that now pass on the hosted NVIDIA runner from broken expectations to ordinary assertions. The checks cover `NeuralODE` and `AugmentedNDELayer` for each of the three Tracker configurations already in the test matrix.

This is test maintenance only. It removes the conditional `broken` annotation without changing package behavior, the test inputs, or the asserted gradient conditions.

## Failing-before evidence

The CUDA job on current `master` reported the same six tests as unexpected passes:

```text
kwargs: (save_everystep = false, save_start = false, sensealg = TrackerAdjoint()))
  cuda_tests.jl:53 Unexpected Pass
  cuda_tests.jl:66 Unexpected Pass
kwargs: (saveat = 0.0f0:0.1f0:1.0f0, sensealg = TrackerAdjoint()))
  cuda_tests.jl:53 Unexpected Pass
  cuda_tests.jl:66 Unexpected Pass
kwargs: (saveat = 0.1f0, sensealg = TrackerAdjoint()))
  cuda_tests.jl:53 Unexpected Pass
  cuda_tests.jl:66 Unexpected Pass
CUDA | 22 pass | 6 error | 1 broken | 29 total
```

Full hosted before evidence: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33395016735/job/99497361638

## Hardware-backed after evidence

On this PR's hosted NVIDIA runner, all six changed Tracker assertions passed as ordinary assertions. The only remaining CUDA error was the separately investigated NeuralDSDE/SOSRI `@test_broken` unexpected pass described below.

```text
Neural ODE | 28 pass | 28 total
CUDA       | 28 pass | 1 error | 29 total
NeuralDSDE/SOSRI: Unexpected Pass
```

Full hosted after evidence: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33455419842/job/99694243321

## Local verification

There is no NVIDIA GPU on this host: `nvidia-smi` is unavailable and `lspci` reports only the ASPEED onboard display adapter. I therefore did not claim a local passing-after CUDA result; this PR's CUDA CI job must provide the hardware-backed after evidence.

The non-GPU QA gate was run on a temporary local composition with the isolated SamePad QA correction because current `master` has that independent failure. The branch pushed by this PR remains CUDA-test-only.

```text
GROUP=QA julia +release --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |  162    162  4m20.3s
     Testing DiffEqFlux tests passed

julia +release -m Runic --check test/CUDA/cuda_tests.jl  # exit 0
typos test/CUDA/cuda_tests.jl                             # exit 0
git diff --check                                          # exit 0
```

A docs build is not applicable to this test-only change.

## Separate stochastic GPU flake

The existing NeuralDSDE/SOSRI `@test_broken` is intentionally unchanged. It alternates between broken and unexpected-pass outcomes even with Zygote 0.7.12: it unexpectedly passed in https://github.com/SciML/DiffEqFlux.jl/actions/runs/33313814364 and https://github.com/SciML/DiffEqFlux.jl/actions/runs/33313812561, but remained broken in https://github.com/SciML/DiffEqFlux.jl/actions/runs/33311630650 and https://github.com/SciML/DiffEqFlux.jl/actions/runs/33395016735. The marker originated in https://github.com/SciML/DiffEqFlux.jl/commit/1dcd5f0e9b34af56b7860ae897cade3ad56fcb25; https://github.com/SciML/DiffEqFlux.jl/commit/6d99c4a36c55a1a41b03fc6ed6c27dc2c6563ecf later changed only final-state selection.

That stochastic case needs a separate investigation that makes its noise deterministic and validates the actual assertion. A coincidental unexpected pass is not enough evidence to promote it here.

## Links

- Current-master CUDA failure: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33395016735/job/99497361638
- Stochastic unexpected pass, run 1: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33313814364
- Stochastic unexpected pass, run 2: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33313812561
- Stochastic broken outcome, run 1: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33311630650
- Stochastic broken outcome, run 2: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33395016735
- Original stochastic marker commit: https://github.com/SciML/DiffEqFlux.jl/commit/1dcd5f0e9b34af56b7860ae897cade3ad56fcb25
- Final-state test update: https://github.com/SciML/DiffEqFlux.jl/commit/6d99c4a36c55a1a41b03fc6ed6c27dc2c6563ecf

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: local session ID 01a0598f-11b9-72d1-91d9-b2fbb186557d)


