### PR TITLE
[temporary integration] Validate seeded SOSRI noise on CUDA

### DIFF
--- a/test/CUDA/Project.toml
+++ b/test/CUDA/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 DiffEqFlux = "aae7a2af-3d4f-5e19-a356-7da93b79d9d0"
+DiffEqNoiseProcess = "77a26b50-5914-5dd7-bc55-306e6241c503"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 Lux = "b2108857-7c20-44ae-9111-449ecde12c47"
 LuxCUDA = "d0bbae9a-e099-4d5b-a835-1c6931763bda"
@@ -11,6 +12,9 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[sources]
+DiffEqNoiseProcess = {rev = "74230d9e3ccc6d6b5de7f62bf39a76784db0738a", url = "https://github.com/ChrisRackauckas-Claude/DiffEqNoiseProcess.jl.git"}
 
 [compat]
 SciMLTesting = "2.4"

--- a/test/CUDA/cuda_tests.jl
+++ b/test/CUDA/cuda_tests.jl
@@ -79,13 +79,14 @@ else
             # CuVector seems broken on CI but I can't reproduce the failure locally
 
             sode = NeuralDSDE(
-                dudt, diffusion, tspan, solver; saveat = 0.0f0:0.01f0:0.1f0, dt = 0.01f0
+                dudt, diffusion, tspan, solver;
+                saveat = 0.0f0:0.01f0:0.1f0, dt = 0.01f0, seed = UInt64(0x5eed)
             )
             pd, st = Lux.setup(rng, sode)
             pd = ComponentArray(pd) |> gdev
             st = st |> gdev
 
-            @test_broken begin
+            @test begin
                 grads = Zygote.gradient(sum ∘ final_state ∘ sode, u0, pd, st)
                 CUDA.@allowscalar begin
                     !iszero(grads[1]) && !iszero(grads[2]) && !iszero(grads[2][end])

--- a/test/CUDA/cuda_tests.jl
+++ b/test/CUDA/cuda_tests.jl
@@ -47,15 +47,12 @@ else
                     pd, st = Lux.setup(rng, node)
                     pd = ComponentArray(pd) |> gdev
                     st = st |> gdev
-                    broken = hasfield(typeof(kwargs), :sensealg) &&
-                        ndims(u0) == 2 &&
-                        kwargs.sensealg isa TrackerAdjoint
                     @test begin
                         grads = Zygote.gradient(sum ∘ final_state ∘ node, u0, pd, st)
                         CUDA.@allowscalar begin
                             !iszero(grads[1]) && !iszero(grads[2])
                         end
-                    end broken = broken
+                    end
 
                     anode = AugmentedNDELayer(
                         NeuralODE(aug_dudt, tspan, Tsit5(); kwargs...), 2
@@ -68,7 +65,7 @@ else
                         CUDA.@allowscalar begin
                             !iszero(grads[1]) && !iszero(grads[2])
                         end
-                    end broken = broken
+                    end
                 end
             end
         end


### PR DESCRIPTION
## Temporary integration only

This draft is a validation composition and should not be merged. It stacks the six Tracker assertion promotions from https://github.com/SciML/DiffEqFlux.jl/pull/1074 with the seeded SOSRI assertion, and pins the CUDA test environment to the backend-preserving DiffEqNoiseProcess fix in https://github.com/SciML/DiffEqNoiseProcess.jl/pull/328 at exact commit https://github.com/SciML/DiffEqNoiseProcess.jl/commit/74230d9e3ccc6d6b5de7f62bf39a76784db0738a.

Its purpose was to obtain V100 evidence for the owner fix before changing or closing https://github.com/SciML/DiffEqFlux.jl/pull/1075. The seeded gradient assertion itself is unchanged.

## Before evidence

Without the owner fix, the seeded SOSRI test generated a host `Matrix{Float32}` in `DiffEqNoiseProcess.WHITE_NOISE_BRIDGE` and attempted to broadcast it with a `CuDeviceMatrix`; GPUCompiler rejected the non-bitstype host matrix. The hosted job finished with 22 passed and 7 errors: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33463611417/job/99718809319.

## Local composition checks

```text
$ GROUP=CUDA julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
DiffEqNoiseProcess v5.36.2 `https://github.com/ChrisRackauckas-Claude/DiffEqNoiseProcess.jl.git#74230d9`
[ Info: CUDA not functional, skipping CUDA tests
Test Summary: | Broken  Total
CUDA          |      1      1
Testing DiffEqFlux tests passed

$ julia +1.12 --startup-file=no -m Runic --check test/CUDA/cuda_tests.jl
$ typos test/CUDA/cuda_tests.jl test/CUDA/Project.toml
$ git diff --check
# all exited 0 with no output
```

There is no NVIDIA GPU on the local host (`nvidia-smi` is unavailable), so the actual CUDA assertion could not be checked locally. A broader QA run was stopped during Aqua persistent-task checking to queue the hardware discriminator immediately; it is incomplete and is not presented as a pass. This branch does not change QA, including the independently known `SamePad` documentation failure.

## Hosted CUDA passing-after

The hosted V100 job resolved the exact owner revision and passed all 29 CUDA assertions, including the six Tracker assertions and the seeded SOSRI assertion:

```text
DiffEqNoiseProcess v5.36.2 `https://github.com/ChrisRackauckas-Claude/DiffEqNoiseProcess.jl.git#74230d9`
Test Summary: | Pass  Total     Time
CUDA          |   29     29  6m50.5s
Testing DiffEqFlux tests passed
```

Passing-after job: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33475910630/job/99755007706.

## Independent hosted failures

Downgrade QA failed only its public-docstring assertion with exactly `[:AutoModelingToolkit, :SamePad]`: 159 passed, 1 failed, 160 total. Aqua's persistent-task check passed 1/1 in 3m44.4s. This is the known current-master downgrade result because this temporary composition does not stack the ADTypes floor from https://github.com/SciML/DiffEqFlux.jl/pull/1073; neither missing docstring is caused by the CUDA test or DiffEqNoiseProcess source pin.

Current-dependency QA reported exactly `[:SamePad]` as its missing-docstring set. It also reproduced the independent Aqua runner symptom `/tmp/.../done.log was not created, but precompilation exited`, so its summary is 160 passed, 2 failed, 162 total rather than SamePad-only. The same Aqua symptom occurred on PR1073, while clean local QA and this branch's downgrade QA both completed the persistent-task check successfully; it is not caused by this CUDA-only composition and is not suppressed here.

- Downgrade QA: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33475910946/job/99755008864
- Current-dependency QA: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33475911239/job/99755086152
- Independent PR1073 current-QA occurrence: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33454317118/job/99690954775

Please ignore this PR until it has been reviewed by @ChrisRackauckas.

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: local session ID 01a0598f-11b9-72d1-91d9-b2fbb186557d)
