### PR TITLE
[temporary integration] Validate StableRNG SOSRI noise dispatch on CUDA

### DIFF
--- a/test/CUDA/Project.toml
+++ b/test/CUDA/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 DiffEqFlux = "aae7a2af-3d4f-5e19-a356-7da93b79d9d0"
+DiffEqNoiseProcess = "77a26b50-5914-5dd7-bc55-306e6241c503"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 Lux = "b2108857-7c20-44ae-9111-449ecde12c47"
 LuxCUDA = "d0bbae9a-e099-4d5b-a835-1c6931763bda"
@@ -11,6 +12,9 @@ StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[sources]
+DiffEqNoiseProcess = {rev = "8fbbcb12d5547c2d9dd563cdfee4c13d52e1067c", url = "https://github.com/ChrisRackauckas-Claude/DiffEqNoiseProcess.jl.git"}
 
 [compat]
 SciMLTesting = "2.4"


### PR DESCRIPTION
## Temporary integration only

This draft is a validation composition and should not be merged. DiffEqFlux `master` already contains the StableRNG CUDA test from https://github.com/SciML/DiffEqFlux.jl/pull/1075; this branch only pins the CUDA test environment to the backend-preserving DiffEqNoiseProcess fix in https://github.com/SciML/DiffEqNoiseProcess.jl/pull/328 at exact commit https://github.com/SciML/DiffEqNoiseProcess.jl/commit/8fbbcb12d5547c2d9dd563cdfee4c13d52e1067c.

Its purpose is to obtain current V100 evidence for the combined fix. The test and production sources are unchanged on this branch.

## Before evidence

Without the DiffEqNoiseProcess fix, the seeded SOSRI test generated a host `Matrix{Float32}` in `DiffEqNoiseProcess.WHITE_NOISE_BRIDGE` and attempted to broadcast it with a `CuDeviceMatrix`; GPUCompiler rejected the non-bitstype host matrix. The hosted job finished with 22 passed and 7 errors: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33463611417/job/99718809319.

## Local exact-stack verification

```text
$ GROUP=CUDA JULIA_NUM_PRECOMPILE_TASKS=1 julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
DiffEqNoiseProcess v5.36.2 `https://github.com/ChrisRackauckas-Claude/DiffEqNoiseProcess.jl.git#8fbbcb1`
StableRNGs v1.0.4
GPUArrays v11.5.14
[ Info: CUDA not functional, skipping CUDA tests
Test Summary: | Broken  Total   Time
CUDA          |      1      1  26.1s
Testing DiffEqFlux tests passed

$ julia +release --startup-file=no -m Runic --check test/CUDA/cuda_tests.jl
$ typos test/CUDA/cuda_tests.jl test/CUDA/Project.toml
$ git diff --check
# all exited 0
```

This host has no functional NVIDIA GPU, so the actual CUDA assertion could not be checked locally. Julia 1.10 also passed the CPU-only CUDA group, but Julia 1.10 does not honor the test environment's `[sources]` entry; that run is not evidence for the pinned DiffEqNoiseProcess revision.

## Hosted V100 verification

The hosted job resolved the exact owner revision and passed all 29 CUDA assertions:

```text
DiffEqNoiseProcess v5.36.2 `https://github.com/ChrisRackauckas-Claude/DiffEqNoiseProcess.jl.git#8fbbcb1`
StableRNGs v1.0.4
GPUArrays v11.5.14
Test Summary: | Pass  Total     Time
CUDA          |   29     29  7m56.7s
Testing DiffEqFlux tests passed
```

Passing V100 job: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33970922341/job/101319166032.

The independent current-master `SamePad` QA regression is addressed by draft PR https://github.com/SciML/DiffEqFlux.jl/pull/1077. Its downgrade job no longer reports `SamePad`; the remaining `AutoModelingToolkit` failure depends on the separate compatibility fix in https://github.com/SciML/DiffEqFlux.jl/pull/1073.

Please ignore this PR until it has been reviewed by @ChrisRackauckas.

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: local session ID 01a0598f-11b9-72d1-91d9-b2fbb186557d)
