### PR TITLE
Add 32-bit Layers CI lane via test_groups.toml

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,6 +1,12 @@
 [Layers]
 versions = ["lts", "1"]
 
+["Layers 32-bit"]
+group = "Layers"
+versions = ["1"]
+os = ["ubuntu-latest"]
+arch = "x86"
+
 [BasicNeuralDE]
 versions = ["lts", "1"]
 runner = "ubuntu-24.04"


### PR DESCRIPTION

## Summary
- Add a `["Layers 32-bit"]` matrix-only alias (`group = "Layers"`, `arch = "x86"`, Linux only) so this package exercises 32-bit Julia via SciML/.github `@v1`.
- No `[Core]` group in this matrix; alias targets the primary `Layers` lane.

## Test plan
- [ ] CI shows a job with `, x86)` for this group
- [ ] Job green, or failure is a real Int32/WordSize bug to fix
