### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "ComponentArrays,Lux,OrdinaryDiffEqTsit5,StableRNGs"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,51 @@
+using DiffEqFlux, BenchmarkTools
+using Lux, ComponentArrays, StableRNGs
+using OrdinaryDiffEqTsit5
+
+const SUITE = BenchmarkGroup()
+const rng = StableRNG(123)
+
+tspan = (0.0f0, 1.0f0)
+dudt = Chain(Dense(2 => 8, tanh), Dense(8 => 2))
+dudt_aug = Chain(Dense(4 => 8, tanh), Dense(8 => 4))
+u0 = Float32[2.0; 0.0]
+
+# =============================================================================
+# NeuralODE — construction, setup, forward solve
+# =============================================================================
+
+node = NeuralODE(dudt, tspan, Tsit5(); saveat = 0.1f0)
+anode = AugmentedNDELayer(NeuralODE(dudt_aug, tspan, Tsit5()), 2)
+
+pd, st = Lux.setup(rng, node)
+pda, sta = Lux.setup(rng, anode)
+pd = ComponentArray(pd)
+pda = ComponentArray(pda)
+
+SUITE["neural_ode"] = BenchmarkGroup()
+
+SUITE["neural_ode"]["construct"] = @benchmarkable NeuralODE(
+    $dudt, $tspan, Tsit5(); saveat = 0.1f0
+)
+SUITE["neural_ode"]["setup"] = @benchmarkable Lux.setup($rng, $node)
+SUITE["neural_ode"]["forward"] = @benchmarkable first($node($u0, $pd, $st))
+SUITE["neural_ode"]["forward_augmented"] = @benchmarkable first(
+    $anode($u0, $pda, $sta)
+)
+
+# =============================================================================
+# Collocation — non-neural two-stage derivative estimation
+# =============================================================================
+
+t = range(0.0f0, 5.0f0; length = 50)
+data = sin.(t) .+ 0.01f0 .* randn(rng, Float32, length(t))
+data2d = Float32[sin.(t)'; cos.(t)']
+
+SUITE["collocate"] = BenchmarkGroup()
+
+SUITE["collocate"]["kernel"] = @benchmarkable collocate_data(
+    $data2d, $t, EpanechnikovKernel()
+)
+SUITE["collocate"]["triangular"] = @benchmarkable collocate_data(
+    $data2d, $t, TriangularKernel()
+)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~36s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~36s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 Max)
Session: local transcript /home/crackauc/.local/share/devin/cli/summaries/history_ccb52064e6514b21.md